### PR TITLE
Implement support to mint pkp upon WebAuthn signing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -41,11 +41,14 @@ import { LoggedInUser } from "./example-server";
 
 import cors from "cors";
 import { getPubkeyForAuthMethod } from "./lit";
-import { googleOAuthHandler } from "./routes/auth/google";
+import { googleOAuthVerifyToMintHandler } from "./routes/auth/google";
 import { getAuthStatusHandler } from "./routes/auth/status";
 import limiter from "./routes/middlewares/limiter";
 import { storeConditionHandler } from "./routes/storeCondition";
 import apiKeyGateAndTracking from "./routes/middlewares/apiKeyGateAndTracking";
+import { webAuthnAssertionVerifyToMintHandler } from "./routes/auth/webAuthn";
+import { toHash } from "./utils/toHash";
+import { utils } from "ethers";
 
 const app = express();
 
@@ -268,32 +271,18 @@ app.post("/verify-authentication", async (req, res) => {
 
 	const expectedChallenge = user.currentChallenge;
 
-	// let dbAuthenticator;
+	let dbAuthenticator: AuthenticatorDevice;
 	const bodyCredIDBuffer = base64url.toBuffer(body.rawId);
-	// // "Query the DB" here for an authenticator matching `credentialID`
-	// for (const dev of user.devices) {
-	//   if (dev.credentialID.equals(bodyCredIDBuffer)) {
-	//     dbAuthenticator = dev;
-	//     break;
-	//   }
-	// }
+	// "Query the DB" here for an authenticator matching `credentialID`
+	for (const dev of user.devices) {
+		if (dev.credentialID.equals(bodyCredIDBuffer)) {
+			dbAuthenticator = dev;
+			break;
+		}
+	}
+	console.log("dbAuthenticator", dbAuthenticator!);
 
-	// console.log("dbAuthenticator", dbAuthenticator);
-
-	// try and pull it from chain
-	const pubkey = await getPubkeyForAuthMethod({
-		credentialID: bodyCredIDBuffer,
-	});
-	console.log("got pubkey", pubkey);
-
-	const dbAuthenticator: AuthenticatorDevice = {
-		credentialID: bodyCredIDBuffer,
-		credentialPublicKey: Buffer.from(pubkey.slice(2), "hex"),
-		transports: ["internal"],
-		counter: 0,
-	};
-
-	if (!dbAuthenticator) {
+	if (!dbAuthenticator!) {
 		return res
 			.status(400)
 			.send({ error: "Authenticator is not registered with this site" });
@@ -328,9 +317,10 @@ app.post("/verify-authentication", async (req, res) => {
 	res.send({ verified });
 });
 
-app.post("/store-condition", storeConditionHandler);
-app.post("/auth/google", googleOAuthHandler);
+app.post("/store-condition", limiter, storeConditionHandler);
+app.post("/auth/google", googleOAuthVerifyToMintHandler);
 app.get("/auth/status/:requestId", getAuthStatusHandler);
+app.post("/auth/webauthn", webAuthnAssertionVerifyToMintHandler);
 
 if (ENABLE_HTTPS) {
 	const host = "0.0.0.0";
@@ -356,7 +346,7 @@ if (ENABLE_HTTPS) {
 } else {
 	const host = "127.0.0.1";
 	const port = parseInt(PORT);
-	expectedOrigin = `http://localhost:${port}`;
+	expectedOrigin = `http://localhost:3000`;
 
 	http.createServer(app).listen(port, () => {
 		console.log(`🚀 Server ready at ${expectedOrigin} (${host}:${port})`);

--- a/models/index.ts
+++ b/models/index.ts
@@ -1,10 +1,16 @@
-export interface GoogleOAuthRequest {
+export interface GoogleOAuthVerifyToMintRequest {
 	idToken: string;
 }
 
-export interface GoogleOAuthResponse {
+export interface AuthMethodVerifyToMintResponse {
 	requestId?: string;
 	error?: string;
+}
+
+export interface WebAuthnAssertionVerifyToMintRequest {
+	signature: string;
+	signatureBase: string;
+	credentialPublicKey: string;
 }
 
 export interface GetAuthStatusRequestParams {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
+    "@types/cbor": "^6.0.0",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
+    "@types/jwk-to-pem": "^2.0.1",
     "@types/node": "^16.7.4",
     "@types/node-fetch": "^2.5.12",
     "nodemon": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "base64url": "^3.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
+    "elliptic": "^6.5.4",
     "ethers": "^5.7.1",
     "express": "^4.17.1",
     "express-rate-limit": "^6.6.0",
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@types/cbor": "^6.0.0",
     "@types/cors": "^2.8.12",
+    "@types/elliptic": "^6.4.14",
     "@types/express": "^4.17.13",
     "@types/jwk-to-pem": "^2.0.1",
     "@types/node": "^16.7.4",

--- a/routes/auth/google.ts
+++ b/routes/auth/google.ts
@@ -3,8 +3,8 @@ import { Response } from "express-serve-static-core";
 import { ParsedQs } from "qs";
 import {
 	AuthMethodType,
-	GoogleOAuthRequest,
-	GoogleOAuthResponse,
+	GoogleOAuthVerifyToMintRequest,
+	AuthMethodVerifyToMintResponse,
 } from "../../models";
 import { OAuth2Client, TokenPayload } from "google-auth-library";
 import { utils } from "ethers";
@@ -24,15 +24,15 @@ async function verifyIDToken(idToken: string): Promise<TokenPayload> {
 	return ticket.getPayload()!;
 }
 
-export async function googleOAuthHandler(
+export async function googleOAuthVerifyToMintHandler(
 	req: Request<
 		{},
-		GoogleOAuthResponse,
-		GoogleOAuthRequest,
+		AuthMethodVerifyToMintResponse,
+		GoogleOAuthVerifyToMintRequest,
 		ParsedQs,
 		Record<string, any>
 	>,
-	res: Response<GoogleOAuthResponse, Record<string, any>, number>,
+	res: Response<AuthMethodVerifyToMintResponse, Record<string, any>, number>,
 ) {
 	// get idToken from body
 	const { idToken } = req.body;

--- a/routes/auth/webAuthn.ts
+++ b/routes/auth/webAuthn.ts
@@ -1,0 +1,66 @@
+import { utils } from "ethers";
+import { Request } from "express";
+import { Response } from "express-serve-static-core";
+import { ParsedQs } from "qs";
+import { mintPKP } from "../../lit";
+import {
+	AuthMethodType,
+	AuthMethodVerifyToMintResponse,
+	WebAuthnAssertionVerifyToMintRequest,
+} from "../../models";
+import { verifySignature } from "../../utils/webAuthn/verifySignature";
+
+export async function webAuthnAssertionVerifyToMintHandler(
+	req: Request<
+		{},
+		AuthMethodVerifyToMintResponse,
+		WebAuthnAssertionVerifyToMintRequest,
+		ParsedQs,
+		Record<string, any>
+	>,
+	res: Response<AuthMethodVerifyToMintResponse, Record<string, any>, number>,
+) {
+	// get parameters from body
+	const { signature, signatureBase, credentialPublicKey } = req.body;
+
+	// verify WebAuthn signature
+	try {
+		const signatureValid = await verifySignature({
+			signature: Buffer.from(utils.arrayify(signature)),
+			signatureBase: Buffer.from(utils.arrayify(signatureBase)),
+			credentialPublicKey: Buffer.from(
+				utils.arrayify(credentialPublicKey),
+			),
+		});
+
+		if (!signatureValid) {
+			return res.status(400).json({
+				error: "Invalid signature",
+			});
+		}
+
+		console.info("Signature valid", { credentialPublicKey });
+	} catch (err) {
+		console.error("Unable to verify signature", { err });
+		return res.status(500).json({
+			error: "Unable to verify signature",
+		});
+	}
+
+	// mint PKP for user
+	try {
+		const idForAuthMethod = utils.keccak256(credentialPublicKey);
+		const mintTx = await mintPKP({
+			authMethodType: AuthMethodType.WebAuthn,
+			idForAuthMethod,
+		});
+		return res.status(200).json({
+			requestId: mintTx.hash,
+		});
+	} catch (err) {
+		console.error("Unable to mint PKP for user", { err });
+		return res.status(500).json({
+			error: "Unable to mint PKP for user",
+		});
+	}
+}

--- a/routes/auth/webAuthn.ts
+++ b/routes/auth/webAuthn.ts
@@ -9,6 +9,8 @@ import {
 	WebAuthnAssertionVerifyToMintRequest,
 } from "../../models";
 import { verifySignature } from "../../utils/webAuthn/verifySignature";
+import { decodeECKeyAndGetPublicKey } from "../../utils/webAuthn/keys";
+import { toUtf8Bytes } from "ethers/lib/utils";
 
 export async function webAuthnAssertionVerifyToMintHandler(
 	req: Request<
@@ -49,7 +51,14 @@ export async function webAuthnAssertionVerifyToMintHandler(
 
 	// mint PKP for user
 	try {
-		const idForAuthMethod = utils.keccak256(credentialPublicKey);
+		const decodedPublicKey = decodeECKeyAndGetPublicKey(
+			Buffer.from(utils.arrayify(credentialPublicKey)),
+		);
+		console.log("Deriving ID for auth method", { decodedPublicKey });
+
+		const idForAuthMethod = utils.keccak256(
+			toUtf8Bytes(`0x${decodedPublicKey}:TODO:`),
+		);
 		const mintTx = await mintPKP({
 			authMethodType: AuthMethodType.WebAuthn,
 			idForAuthMethod,

--- a/utils/cbor.ts
+++ b/utils/cbor.ts
@@ -1,0 +1,34 @@
+// copy-🍝 from https://github.com/MasterKale/SimpleWebAuthn/blob/33528afe001d4aca62052dce204c0398c3127ffd/packages/server/src/helpers/decodeCbor.ts
+
+import cbor from "cbor";
+
+export function decodeCborFirst(
+	input:
+		| string
+		| Buffer
+		| ArrayBuffer
+		| Uint8Array
+		| Uint8ClampedArray
+		| DataView,
+): any {
+	try {
+		// throws if there are extra bytes
+		return cbor.decodeFirstSync(input);
+	} catch (err) {
+		const _err = err as CborDecoderError;
+		// if the error was due to extra bytes, return the unpacked value
+		if (_err.value) {
+			return _err.value;
+		}
+		throw err;
+	}
+}
+
+/**
+ * Intuited from a quick scan of `cbor.decodeFirstSync()` here:
+ *
+ * https://github.com/hildjj/node-cbor/blob/v5.1.0/lib/decoder.js#L189
+ */
+class CborDecoderError extends Error {
+	value: any;
+}

--- a/utils/toHash.ts
+++ b/utils/toHash.ts
@@ -1,0 +1,12 @@
+// copy-🍝 from https://github.com/MasterKale/SimpleWebAuthn/blob/33528afe001d4aca62052dce204c0398c3127ffd/packages/server/src/helpers/toHash.ts#L8
+
+import crypto from "crypto";
+
+/**
+ * Returns hash digest of the given data using the given algorithm.
+ * @param data Data to hash
+ * @return The hash
+ */
+export function toHash(data: Buffer | string, algo = "SHA256"): Buffer {
+	return crypto.createHash(algo).update(data).digest();
+}

--- a/utils/webAuthn/convertCOSEtoPKCS.ts
+++ b/utils/webAuthn/convertCOSEtoPKCS.ts
@@ -1,0 +1,100 @@
+import { COSEAlgorithmIdentifier } from "@simplewebauthn/typescript-types";
+import { decodeCborFirst } from "../cbor";
+
+/**
+ * Takes COSE-encoded public key and converts it to PKCS key
+ */
+export function convertCOSEtoPKCS(cosePublicKey: Buffer): Buffer {
+	const struct: COSEPublicKey = decodeCborFirst(cosePublicKey);
+
+	const tag = Buffer.from([0x04]);
+	const x = struct.get(COSEKEYS.x);
+	const y = struct.get(COSEKEYS.y);
+
+	if (!x) {
+		throw new Error("COSE public key was missing x");
+	}
+
+	if (y) {
+		return Buffer.concat([tag, x as Buffer, y as Buffer]);
+	}
+
+	return Buffer.concat([tag, x as Buffer]);
+}
+
+export type COSEPublicKey = Map<COSEAlgorithmIdentifier, number | Buffer>;
+
+export enum COSEKEYS {
+	kty = 1,
+	alg = 3,
+	crv = -1,
+	x = -2,
+	y = -3,
+	n = -1,
+	e = -2,
+}
+
+export enum COSEKTY {
+	OKP = 1,
+	EC2 = 2,
+	RSA = 3,
+}
+
+export const COSERSASCHEME: { [key: string]: SigningSchemeHash } = {
+	"-3": "pss-sha256",
+	"-39": "pss-sha512",
+	"-38": "pss-sha384",
+	"-65535": "pkcs1-sha1",
+	"-257": "pkcs1-sha256",
+	"-258": "pkcs1-sha384",
+	"-259": "pkcs1-sha512",
+};
+
+// See https://w3c.github.io/webauthn/#sctn-alg-identifier
+export const COSECRV: { [key: number]: string } = {
+	// alg: -7
+	1: "p256",
+	// alg: -35
+	2: "p384",
+	// alg: -36
+	3: "p521",
+	// alg: -8
+	6: "ed25519",
+};
+
+export const COSEALGHASH: { [key: string]: string } = {
+	"-65535": "sha1",
+	"-259": "sha512",
+	"-258": "sha384",
+	"-257": "sha256",
+	"-39": "sha512",
+	"-38": "sha384",
+	"-37": "sha256",
+	"-36": "sha512",
+	"-35": "sha384",
+	"-8": "sha512",
+	"-7": "sha256",
+};
+
+/**
+ * Imported from node-rsa's types
+ */
+type SigningSchemeHash =
+	| "pkcs1-ripemd160"
+	| "pkcs1-md4"
+	| "pkcs1-md5"
+	| "pkcs1-sha"
+	| "pkcs1-sha1"
+	| "pkcs1-sha224"
+	| "pkcs1-sha256"
+	| "pkcs1-sha384"
+	| "pkcs1-sha512"
+	| "pss-ripemd160"
+	| "pss-md4"
+	| "pss-md5"
+	| "pss-sha"
+	| "pss-sha1"
+	| "pss-sha224"
+	| "pss-sha256"
+	| "pss-sha384"
+	| "pss-sha512";

--- a/utils/webAuthn/convertCertBufferToPEM.ts
+++ b/utils/webAuthn/convertCertBufferToPEM.ts
@@ -1,0 +1,33 @@
+// copy-🍝 from https://github.com/MasterKale/SimpleWebAuthn/blob/33528afe001d4aca62052dce204c0398c3127ffd/packages/server/src/helpers/convertCertBufferToPEM.ts
+
+import base64url from "base64url";
+import type { Base64URLString } from "@simplewebauthn/typescript-types";
+
+/**
+ * Convert buffer to an OpenSSL-compatible PEM text format.
+ */
+export function convertCertBufferToPEM(
+	certBuffer: Buffer | Base64URLString,
+): string {
+	let b64cert: string;
+
+	/**
+	 * Get certBuffer to a base64 representation
+	 */
+	if (typeof certBuffer === "string") {
+		b64cert = base64url.toBase64(certBuffer);
+	} else {
+		b64cert = certBuffer.toString("base64");
+	}
+
+	let PEMKey = "";
+	for (let i = 0; i < Math.ceil(b64cert.length / 64); i += 1) {
+		const start = 64 * i;
+
+		PEMKey += `${b64cert.substr(start, 64)}\n`;
+	}
+
+	PEMKey = `-----BEGIN CERTIFICATE-----\n${PEMKey}-----END CERTIFICATE-----\n`;
+
+	return PEMKey;
+}

--- a/utils/webAuthn/convertPublicKeyToPEM.ts
+++ b/utils/webAuthn/convertPublicKeyToPEM.ts
@@ -1,0 +1,73 @@
+// copy-🍝 from https://github.com/MasterKale/SimpleWebAuthn/blob/33528afe001d4aca62052dce204c0398c3127ffd/packages/server/src/helpers/convertPublicKeyToPEM.ts
+
+import cbor from "cbor";
+import jwkToPem from "jwk-to-pem";
+
+import { COSEKEYS, COSEKTY, COSECRV } from "./convertCOSEtoPKCS";
+
+export function convertPublicKeyToPEM(publicKey: Buffer): string {
+	let struct;
+	try {
+		struct = cbor.decodeAllSync(publicKey)[0];
+	} catch (err) {
+		const _err = err as Error;
+		throw new Error(
+			`Error decoding public key while converting to PEM: ${_err.message}`,
+		);
+	}
+
+	const kty = struct.get(COSEKEYS.kty);
+
+	if (!kty) {
+		throw new Error("Public key was missing kty");
+	}
+
+	if (kty === COSEKTY.EC2) {
+		const crv = struct.get(COSEKEYS.crv);
+		const x = struct.get(COSEKEYS.x);
+		const y = struct.get(COSEKEYS.y);
+
+		if (!crv) {
+			throw new Error("Public key was missing crv (EC2)");
+		}
+
+		if (!x) {
+			throw new Error("Public key was missing x (EC2)");
+		}
+
+		if (!y) {
+			throw new Error("Public key was missing y (EC2)");
+		}
+
+		const ecPEM = jwkToPem({
+			kty: "EC",
+			// Specify curve as "P-256" from "p256"
+			crv: COSECRV[crv as number].replace("p", "P-"),
+			x: (x as Buffer).toString("base64"),
+			y: (y as Buffer).toString("base64"),
+		});
+
+		return ecPEM;
+	} else if (kty === COSEKTY.RSA) {
+		const n = struct.get(COSEKEYS.n);
+		const e = struct.get(COSEKEYS.e);
+
+		if (!n) {
+			throw new Error("Public key was missing n (RSA)");
+		}
+
+		if (!e) {
+			throw new Error("Public key was missing e (RSA)");
+		}
+
+		const rsaPEM = jwkToPem({
+			kty: "RSA",
+			n: (n as Buffer).toString("base64"),
+			e: (e as Buffer).toString("base64"),
+		});
+
+		return rsaPEM;
+	}
+
+	throw new Error(`Could not convert public key type ${kty} to PEM`);
+}

--- a/utils/webAuthn/keys.ts
+++ b/utils/webAuthn/keys.ts
@@ -1,0 +1,21 @@
+import cbor from "cbor";
+import { ec as EC } from "elliptic";
+import { COSEKEYS } from "./convertCOSEtoPKCS";
+
+const ec = new EC("secp256k1");
+
+export function decodeECKeyAndGetPublicKey(
+	cborDecodedPublicKey: Buffer,
+): string {
+	const struct = cbor.decodeAllSync(cborDecodedPublicKey)[0];
+
+	const x = struct.get(COSEKEYS.x);
+	const y = struct.get(COSEKEYS.y);
+
+	const key = ec.keyFromPublic({
+		x,
+		y,
+	});
+
+	return key.getPublic(true, "hex");
+}

--- a/utils/webAuthn/verifySignature.ts
+++ b/utils/webAuthn/verifySignature.ts
@@ -1,0 +1,118 @@
+// copy-🍝 from https://github.com/MasterKale/SimpleWebAuthn/blob/33528afe001d4aca62052dce204c0398c3127ffd/packages/server/src/helpers/verifySignature.ts#L31
+
+import crypto from "crypto";
+import cbor from "cbor";
+import { verify as ed25519Verify } from "@noble/ed25519";
+
+import { COSEKEYS, COSEKTY } from "./convertCOSEtoPKCS";
+import { convertCertBufferToPEM } from "./convertCertBufferToPEM";
+import { convertPublicKeyToPEM } from "./convertPublicKeyToPEM";
+
+type VerifySignatureOptsLeafCert = {
+	signature: Buffer;
+	signatureBase: Buffer;
+	leafCert: Buffer;
+	hashAlgorithm?: string;
+};
+
+type VerifySignatureOptsCredentialPublicKey = {
+	signature: Buffer;
+	signatureBase: Buffer;
+	credentialPublicKey: Buffer;
+	hashAlgorithm?: string;
+};
+
+/**
+ * Verify an authenticator's signature
+ *
+ * @param signature attStmt.sig
+ * @param signatureBase Output from Buffer.concat()
+ * @param publicKey Authenticator's public key as a PEM certificate
+ * @param algo Which algorithm to use to verify the signature (default: `'sha256'`)
+ */
+export async function verifySignature(
+	opts: VerifySignatureOptsLeafCert | VerifySignatureOptsCredentialPublicKey,
+): Promise<boolean> {
+	const { signature, signatureBase, hashAlgorithm = "sha256" } = opts;
+	const _isLeafcertOpts = isLeafCertOpts(opts);
+	const _isCredPubKeyOpts = isCredPubKeyOpts(opts);
+
+	if (!_isLeafcertOpts && !_isCredPubKeyOpts) {
+		throw new Error(
+			'Must declare either "leafCert" or "credentialPublicKey"',
+		);
+	}
+
+	if (_isLeafcertOpts && _isCredPubKeyOpts) {
+		throw new Error(
+			'Must not declare both "leafCert" and "credentialPublicKey"',
+		);
+	}
+
+	let publicKeyPEM = "";
+
+	if (_isCredPubKeyOpts) {
+		const { credentialPublicKey } = opts;
+
+		// Decode CBOR to COSE
+		let struct;
+		try {
+			struct = cbor.decodeAllSync(credentialPublicKey)[0];
+		} catch (err) {
+			const _err = err as Error;
+			throw new Error(
+				`Error decoding public key while converting to PEM: ${_err.message}`,
+			);
+		}
+
+		const kty = struct.get(COSEKEYS.kty);
+
+		if (!kty) {
+			throw new Error("Public key was missing kty");
+		}
+
+		// Check key type
+		if (kty === COSEKTY.OKP) {
+			// Verify Ed25519 slightly differently
+			const x = struct.get(COSEKEYS.x);
+
+			if (!x) {
+				throw new Error("Public key was missing x (OKP)");
+			}
+
+			return ed25519Verify(signature, signatureBase, x);
+		} else {
+			// Convert pubKey to PEM for ECC and RSA
+			publicKeyPEM = convertPublicKeyToPEM(credentialPublicKey);
+		}
+	}
+
+	if (_isLeafcertOpts) {
+		const { leafCert } = opts;
+		publicKeyPEM = convertCertBufferToPEM(leafCert);
+	}
+
+	return crypto
+		.createVerify(hashAlgorithm)
+		.update(signatureBase)
+		.verify(publicKeyPEM, signature);
+}
+
+function isLeafCertOpts(
+	opts: VerifySignatureOptsLeafCert | VerifySignatureOptsCredentialPublicKey,
+): opts is VerifySignatureOptsLeafCert {
+	return (
+		Object.keys(opts as VerifySignatureOptsLeafCert).indexOf("leafCert") >=
+		0
+	);
+}
+
+function isCredPubKeyOpts(
+	opts: VerifySignatureOptsLeafCert | VerifySignatureOptsCredentialPublicKey,
+): opts is VerifySignatureOptsCredentialPublicKey {
+	return (
+		Object.keys(opts as VerifySignatureOptsCredentialPublicKey).indexOf(
+			"credentialPublicKey",
+		) >= 0
+	);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,6 +519,13 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
+"@types/bn.js@*":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.1.tgz#b51e1b55920a4ca26e9285ff79936bbdec910682"
+  integrity sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==
+  dependencies:
+    "@types/node" "*"
+
 "@types/body-parser@*":
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
@@ -545,6 +552,13 @@
   version "2.8.12"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
   integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
+
+"@types/elliptic@^6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.14.tgz#7bbaad60567a588c1f08b10893453e6b9b4de48e"
+  integrity sha512-z4OBcDAU0GVwDTuwJzQCiL6188QvZMkvoERgcVjq0/mPM8jCfdwZ3x5zQEVoL9WCAru3aG5wl3Z5Ww5wBWn7ZQ==
+  dependencies:
+    "@types/bn.js" "*"
 
 "@types/express-serve-static-core@^4.17.18":
   version "4.17.31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,6 +527,13 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/cbor@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/cbor/-/cbor-6.0.0.tgz#ddead015e14ef4463287d40cd92a6297a34dac8d"
+  integrity sha512-mGQ1lbYOwVti5Xlarn1bTeBZqgY0kstsdjnkoEovgohYKdBjGejHyNGXHdMBeqyQazIv32Jjp33+5pBEaSRy2w==
+  dependencies:
+    cbor "*"
+
 "@types/connect@*":
   version "3.4.35"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
@@ -557,6 +564,11 @@
     "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
+
+"@types/jwk-to-pem@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jwk-to-pem/-/jwk-to-pem-2.0.1.tgz#ba6949f447e02cb7bebf101551e3a4dea5f4fde4"
+  integrity sha512-QXmRPhR/LPzvXBHTPfG2BBfMTkNLUD7NyRcPft8m5xFCeANa1BZyLgT0Gw+OxdWx6i1WCpT27EqyggP4UUHMrA==
 
 "@types/mime@*":
   version "3.0.1"
@@ -781,6 +793,13 @@ call-bind@^1.0.0:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
+
+cbor@*:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
+  dependencies:
+    nofilter "^3.1.0"
 
 cbor@^5.1.0:
   version "5.2.0"
@@ -1425,6 +1444,11 @@ nofilter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
   integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
+
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
 
 nopt@~1.0.10:
   version "1.0.10"


### PR DESCRIPTION
# What

This PR implements support to mint a PKP upon a user providing valid authentication material resulting from an assertion being generated via the WebAuthn API.

Specifically,

- New `POST /auth/webauthn` endpoint for users to post their `signature`, `signatureBase` and `credentialPublicKey` (COSE public key that is CBOR encoded) to the relay server in exchange for the relay server to start minting a PKP for that user. The response contains a `requestId` which is meant as a opaque identifier that clients can use against the `GET /auth/status/:requestId` endpoint to check for the status of the auth process. In this case, we simply return the tx hash of the PKP mint TX as the `requestId`. Note that this endpoint waits until the tx has been written to the mempool and passed basic validity checks, but not until the tx has reached any specific number of block confirmations.

# Security

Note that the while this endpoint is susceptible to replay attacks, all the endpoint is doing is minting a PKP for the associated public key of the PassKeys credential, and since the identifier that is authorized to use the minted PKP is derived from the same PassKeys public key, all a replay would result in is a new PKP being minted for the same WebAuthn credentials to be authorized to use it - not the end of the world. 
- We should probably limit it to single-use though ideally.

# Testing

- E2E test possible if you follow setup instructions for a frontend as per https://github.com/LIT-Protocol/oauth-pkp-signup-example/pull/2
- If you want a more minimal test just curl local server with the following:

```json
{
    "signature": "0x30450220048c58582c96b52ec712bf4cae2fafc17804190f0b9443f30af0ddb1a3e4fc85022100b2d4d17ed569464400b04f4e6940a545d798106dd4cd8db0c828e92a9c6ac487",
    "signatureBase": "0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000000d005ada75c6c979118f40bb12dc7800be8494f42d950ca7f49a22bcb9c5aa535",
    "credentialPublicKey": "0xa5010203262001215820774ffde517e2b87a03063f618753ff03f45a0e065a1c08ee92ee813a39391d02225820f438af6a615d73809f7f774f290bd074b1fd2bc76cbdbc380b5b09e49aaeab4a"
}
```