### PR TITLE
Implement API key gating and tracking

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -45,6 +45,7 @@ import { googleOAuthHandler } from "./routes/auth/google";
 import { getAuthStatusHandler } from "./routes/auth/status";
 import limiter from "./routes/middlewares/limiter";
 import { storeConditionHandler } from "./routes/storeCondition";
+import apiKeyGateAndTracking from "./routes/middlewares/apiKeyGateAndTracking";
 
 const app = express();
 
@@ -58,6 +59,9 @@ const {
 app.use(express.static("./public/"));
 app.use(express.json());
 app.use(cors());
+
+app.use(limiter);
+app.use(apiKeyGateAndTracking);
 
 /**
  * If the words "metadata statements" mean anything to you, you'll want to enable this route. It
@@ -324,7 +328,7 @@ app.post("/verify-authentication", async (req, res) => {
 	res.send({ verified });
 });
 
-app.post("/store-condition", limiter, storeConditionHandler);
+app.post("/store-condition", storeConditionHandler);
 app.post("/auth/google", googleOAuthHandler);
 app.get("/auth/status/:requestId", getAuthStatusHandler);
 

--- a/lib/redisClient.ts
+++ b/lib/redisClient.ts
@@ -1,0 +1,19 @@
+import config from "../config";
+
+import * as redis from "redis";
+
+let redisClient: redis.RedisClientType;
+
+(async () => {
+	redisClient = redis.createClient({
+		url: config.redisUrl,
+	});
+
+	redisClient.on("error", (error: Error) =>
+		console.error(`Error : ${error}`),
+	);
+
+	await redisClient.connect();
+})();
+
+export default redisClient!;

--- a/routes/middlewares/apiKeyGateAndTracking.ts
+++ b/routes/middlewares/apiKeyGateAndTracking.ts
@@ -1,0 +1,27 @@
+import { NextFunction, Request } from "express";
+import { Response } from "express-serve-static-core";
+import { ParsedQs } from "qs";
+import redisClient from "../../lib/redisClient";
+
+const API_KEY_HEADER_KEY = "api-key";
+
+export default function apiKeyGateAndTracking(
+	req: Request<{}, any, any, ParsedQs, Record<string, any>>,
+	res: Response<any, Record<string, any>, number>,
+	next: NextFunction,
+) {
+	const apiKey = req.header(API_KEY_HEADER_KEY);
+
+	if (!apiKey) {
+		return res.status(400).json({
+			error: "Missing API key. If you do not have one, please request one at https://forms.gle/osJfmRR2PuZ46Xf98",
+		});
+	}
+
+	// increment tracking
+	const now = new Date();
+	const trackingKey = `${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDate()}:${apiKey}`;
+	redisClient.incr(trackingKey);
+
+	next();
+}

--- a/routes/middlewares/limiter.ts
+++ b/routes/middlewares/limiter.ts
@@ -1,22 +1,6 @@
-import config from "../../config";
-
-import * as redis from "redis";
 import rateLimit from "express-rate-limit";
 import RedisStore from "rate-limit-redis";
-
-let redisClient: any;
-
-(async () => {
-	redisClient = redis.createClient({
-		url: config.redisUrl,
-	});
-
-	redisClient.on("error", (error: Error) =>
-		console.error(`Error : ${error}`),
-	);
-
-	await redisClient.connect();
-})();
+import redisClient from "../../lib/redisClient";
 
 const limiter = rateLimit({
 	// Redis store configuration


### PR DESCRIPTION
# What

This PR implements API key based endpoint gating and usage tracking. Specifically,

- We return 400 statuses for all requests if the `api-key` header is not present.
- We direct users to our Google Form to request an API key.
- We increment a counter in Redis with the key corresponding to the current date + the api key. We can just manually observe the usage patterns for now and can implement a separate ingestion / analytic engine.

# Usage Tracking

We can get all the keys related to an API key's usage with `KEYS "*:<API_KEY>"`

Or we can get all the users of our API on a particular day with `KEYS "2022-12-19:*"`