### PR TITLE
[Draft] Support more auth methods & add fetching pkps

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Note: WebAuthn implementation is still a work in progress and will likely change
 | HTTP Verb | Path                             | Description                                                        |
 | --------- | -------------------------------- | ------------------------------------------------------------------ |
 | GET       | /generate-registration-options   | Register (i.e., create an account) via supported authenticator     |
-| POST      | /generate-authentication-options | Authenticate (i.e., login) via previously-registered authenticator |
+| GET       | /generate-authentication-options | Authenticate (i.e., login) via previously-registered authenticator |
 | POST      | /verify-registration             | Verify the authenticator's response                                |
 
 </br>

--- a/README.md
+++ b/README.md
@@ -14,21 +14,65 @@ The Relay Server hosted by the Lit Protocol team currently only interacts with t
 
 ### Prerequisites
 
-- Install Redis and have a valid connection to it
-- Have access to a valid RPC service endpoint for the network you plan to interact with
-- Have access to a ECDSA private key, with its corresponding wallet containing some funds on the network you plan to interact with
+-   Install Redis and have a valid connection to it
+-   Have access to a valid RPC service endpoint for the network you plan to interact with
+-   Have access to a ECDSA private key, with its corresponding wallet containing some funds on the network you plan to interact with
 
 ### Instructions
 
 Create a `.env` file at the root of the repo and populate the corresponding environment variables:
 
-- `REDIS_URL`
-- `PORT`
-- `LIT_TXSENDER_RPC_URL`
-- `LIT_TXSENDER_PRIVATE_KEY`
+-   `REDIS_URL`
+-   `PORT`
+-   `LIT_TXSENDER_RPC_URL`
+-   `LIT_TXSENDER_PRIVATE_KEY`
 
 Make sure to start your Redis server if you plan to host one locally.
 
 Run `yarn install` to install the dependencies.
 
 Run `yarn start` to start the server.
+
+</br>
+
+## Available Endpoints
+
+Note: WebAuthn implementation is still a work in progress and will likely change.
+
+### Minting PKPs
+
+| HTTP Verb | Path                    | Description                              |
+| --------- | ----------------------- | ---------------------------------------- |
+| POST      | /auth/google            | Mint PKP for authorized Google account   |
+| POST      | /auth/discord           | Mint PKP for authorized Discord account  |
+| POST      | /auth/wallet            | Mint PKP for verified Eth wallet account |
+| POST      | /auth/webauthn          | Mint PKP for verified WebAuthn signature |
+| GET       | /auth/status/:requestId | Poll status of minting PKP transaction   |
+
+</br>
+
+### Fetching PKPs
+
+| HTTP Verb | Path                   | Description                                           |
+| --------- | ---------------------- | ----------------------------------------------------- |
+| POST      | /auth/google/userinfo  | Fetch PKPs associated with authorized Google account  |
+| POST      | /auth/discord/userinfo | Mint PKPs associated with authorized Discord account  |
+| POST      | /auth/wallet/userinfo  | Mint PKPs associated with verified Eth wallet account |
+
+</br>
+
+### Handling WebAuthn
+
+| HTTP Verb | Path                             | Description                                                        |
+| --------- | -------------------------------- | ------------------------------------------------------------------ |
+| GET       | /generate-registration-options   | Register (i.e., create an account) via supported authenticator     |
+| POST      | /generate-authentication-options | Authenticate (i.e., login) via previously-registered authenticator |
+| POST      | /verify-registration             | Verify the authenticator's response                                |
+
+</br>
+
+### Storing Conditions
+
+| HTTP Verb | Path             | Description                          |
+| --------- | ---------------- | ------------------------------------ |
+| POST      | /store-condition | Write encryption conditions to chain |

--- a/index.ts
+++ b/index.ts
@@ -48,15 +48,13 @@ import { getAuthStatusHandler } from "./routes/auth/status";
 import limiter from "./routes/middlewares/limiter";
 import { storeConditionHandler } from "./routes/storeCondition";
 import { webAuthnAssertionVerifyToMintHandler } from "./routes/auth/webAuthn";
-import { toHash } from "./utils/toHash";
-import { utils } from "ethers";
 import {
-	discordOAuthVerifyToFetchHandler,
+	discordOAuthVerifyToFetchPKPsHandler,
 	discordOAuthVerifyToMintHandler,
 } from "./routes/auth/discord";
 import {
 	walletVerifyToMintHandler,
-	walletVerifyToFetchHandler,
+	walletVerifyToFetchPKPsHandler,
 } from "./routes/auth/wallet";
 import apiKeyGateAndTracking from "./routes/middlewares/apiKeyGateAndTracking";
 
@@ -327,22 +325,23 @@ app.post("/verify-authentication", async (req, res) => {
 	res.send({ verified });
 });
 
-// --- Store condition route
+// --- Store condition
 app.post("/store-condition", storeConditionHandler);
 
-// --- Fetch PKP routes
-app.post("/auth/google", googleOAuthVerifyToFetchPKPsHandler);
-app.post("/auth/discord", discordOAuthVerifyToFetchHandler);
-app.post("/auth/wallet", walletVerifyToFetchHandler);
+// --- Mint PKP for authorized account
+app.post("/auth/google", googleOAuthVerifyToMintHandler);
+app.post("/auth/discord", discordOAuthVerifyToMintHandler);
+app.post("/auth/wallet", walletVerifyToMintHandler);
 
+// TODO: Implement safe version of WebAuthn
 app.post("/auth/webauthn", webAuthnAssertionVerifyToMintHandler);
 
-// --- Mint PKP routes
-app.post("/mint/google", googleOAuthVerifyToMintHandler);
-app.post("/mint/discord", discordOAuthVerifyToMintHandler);
-app.post("/mint/wallet", walletVerifyToMintHandler);
+// --- Fetch PKPs tied to authorized account
+app.post("/auth/google/userinfo", googleOAuthVerifyToFetchPKPsHandler);
+app.post("/auth/discord/userinfo", discordOAuthVerifyToFetchPKPsHandler);
+app.post("/auth/wallet/userinfo", walletVerifyToFetchPKPsHandler);
 
-// --- Poll routes
+// --- Poll minting progress
 app.get("/auth/status/:requestId", getAuthStatusHandler);
 
 if (ENABLE_HTTPS) {

--- a/index.ts
+++ b/index.ts
@@ -58,6 +58,7 @@ import {
 	walletVerifyToMintHandler,
 	walletVerifyToFetchHandler,
 } from "./routes/auth/wallet";
+import apiKeyGateAndTracking from "./routes/middlewares/apiKeyGateAndTracking";
 
 const app = express();
 
@@ -71,6 +72,9 @@ const {
 app.use(express.static("./public/"));
 app.use(express.json());
 app.use(cors());
+
+app.use(limiter);
+app.use(apiKeyGateAndTracking);
 
 /**
  * If the words "metadata statements" mean anything to you, you'll want to enable this route. It
@@ -324,19 +328,19 @@ app.post("/verify-authentication", async (req, res) => {
 });
 
 // --- Store condition route
-app.post("/store-condition", limiter, storeConditionHandler);
-
-// --- Mint PKP routes
-app.post("/mint/google", googleOAuthVerifyToMintHandler);
-app.post("/mint/discord", discordOAuthVerifyToMintHandler);
-app.post("/mint/wallet", walletVerifyToMintHandler);
-
-app.post("/auth/webauthn", webAuthnAssertionVerifyToMintHandler);
+app.post("/store-condition", storeConditionHandler);
 
 // --- Fetch PKP routes
 app.post("/auth/google", googleOAuthVerifyToFetchPKPsHandler);
 app.post("/auth/discord", discordOAuthVerifyToFetchHandler);
 app.post("/auth/wallet", walletVerifyToFetchHandler);
+
+app.post("/auth/webauthn", webAuthnAssertionVerifyToMintHandler);
+
+// --- Mint PKP routes
+app.post("/mint/google", googleOAuthVerifyToMintHandler);
+app.post("/mint/discord", discordOAuthVerifyToMintHandler);
+app.post("/mint/wallet", walletVerifyToMintHandler);
 
 // --- Poll routes
 app.get("/auth/status/:requestId", getAuthStatusHandler);

--- a/index.ts
+++ b/index.ts
@@ -40,14 +40,24 @@ import type {
 import { LoggedInUser } from "./example-server";
 
 import cors from "cors";
-import { getPubkeyForAuthMethod } from "./lit";
-import { googleOAuthVerifyToMintHandler } from "./routes/auth/google";
+import {
+	googleOAuthVerifyToFetchPKPsHandler,
+	googleOAuthVerifyToMintHandler,
+} from "./routes/auth/google";
 import { getAuthStatusHandler } from "./routes/auth/status";
 import limiter from "./routes/middlewares/limiter";
 import { storeConditionHandler } from "./routes/storeCondition";
 import { webAuthnAssertionVerifyToMintHandler } from "./routes/auth/webAuthn";
 import { toHash } from "./utils/toHash";
 import { utils } from "ethers";
+import {
+	discordOAuthVerifyToFetchHandler,
+	discordOAuthVerifyToMintHandler,
+} from "./routes/auth/discord";
+import {
+	walletVerifyToMintHandler,
+	walletVerifyToFetchHandler,
+} from "./routes/auth/wallet";
 
 const app = express();
 
@@ -313,10 +323,23 @@ app.post("/verify-authentication", async (req, res) => {
 	res.send({ verified });
 });
 
+// --- Store condition route
 app.post("/store-condition", limiter, storeConditionHandler);
-app.post("/auth/google", googleOAuthVerifyToMintHandler);
-app.get("/auth/status/:requestId", getAuthStatusHandler);
+
+// --- Mint PKP routes
+app.post("/mint/google", googleOAuthVerifyToMintHandler);
+app.post("/mint/discord", discordOAuthVerifyToMintHandler);
+app.post("/mint/wallet", walletVerifyToMintHandler);
+
 app.post("/auth/webauthn", webAuthnAssertionVerifyToMintHandler);
+
+// --- Fetch PKP routes
+app.post("/auth/google", googleOAuthVerifyToFetchPKPsHandler);
+app.post("/auth/discord", discordOAuthVerifyToFetchHandler);
+app.post("/auth/wallet", walletVerifyToFetchHandler);
+
+// --- Poll routes
+app.get("/auth/status/:requestId", getAuthStatusHandler);
 
 if (ENABLE_HTTPS) {
 	const host = "0.0.0.0";

--- a/lib/redisClient.ts
+++ b/lib/redisClient.ts
@@ -1,0 +1,19 @@
+import config from "../config";
+
+import * as redis from "redis";
+
+let redisClient: redis.RedisClientType;
+
+(async () => {
+	redisClient = redis.createClient({
+		url: config.redisUrl,
+	});
+
+	redisClient.on("error", (error: Error) =>
+		console.error(`Error : ${error}`),
+	);
+
+	await redisClient.connect();
+})();
+
+export default redisClient!;

--- a/models/index.ts
+++ b/models/index.ts
@@ -1,9 +1,18 @@
-export interface GoogleOAuthVerifyToMintRequest {
+export interface GoogleOAuthRequest {
 	idToken: string;
+}
+
+export interface DiscordOAuthRequest {
+	accessToken: string;
 }
 
 export interface AuthMethodVerifyToMintResponse {
 	requestId?: string;
+	error?: string;
+}
+
+export interface AuthMethodVerifyToFetchResponse {
+	pkps?: PKP[];
 	error?: string;
 }
 
@@ -19,6 +28,7 @@ export interface GetAuthStatusRequestParams {
 
 export interface GetAuthStatusResponse {
 	status?: AuthStatus;
+	pkpTokenId?: string;
 	pkpEthAddress?: string;
 	pkpPublicKey?: string;
 	error?: string;
@@ -100,4 +110,10 @@ export enum AuthMethodType {
 	Discord,
 	Google,
 	GoogleJwt,
+}
+
+export interface PKP {
+	tokenId: string;
+	publicKey: string;
+	ethAddress: string;
 }

--- a/routes/auth/google.ts
+++ b/routes/auth/google.ts
@@ -18,6 +18,7 @@ const CLIENT_ID =
 
 const client = new OAuth2Client(CLIENT_ID);
 
+// Validate given Google ID token
 async function verifyIDToken(idToken: string): Promise<TokenPayload> {
 	const ticket = await client.verifyIdToken({
 		idToken,
@@ -26,6 +27,7 @@ async function verifyIDToken(idToken: string): Promise<TokenPayload> {
 	return ticket.getPayload()!;
 }
 
+// Mint PKP for verified Google account
 export async function googleOAuthVerifyToMintHandler(
 	req: Request<
 		{},
@@ -39,17 +41,17 @@ export async function googleOAuthVerifyToMintHandler(
 	// get idToken from body
 	const { idToken } = req.body;
 
-	// verify idToken
+	// verify Google ID token
 	let tokenPayload: TokenPayload | null = null;
 	try {
 		tokenPayload = await verifyIDToken(idToken);
-		console.info("Successfully verified user", {
+		console.info("Successfully verified Google account", {
 			userId: tokenPayload.sub,
 		});
 	} catch (err) {
-		console.error("Unable to verify Google idToken", { err });
+		console.error("Unable to verify Google account", { err });
 		return res.status(400).json({
-			error: "Unable to verify Google idToken",
+			error: "Unable to verify Google account",
 		});
 	}
 
@@ -62,17 +64,21 @@ export async function googleOAuthVerifyToMintHandler(
 			authMethodType: AuthMethodType.GoogleJwt,
 			idForAuthMethod,
 		});
+		console.info("Minting PKP with Google auth", {
+			requestId: mintTx.hash,
+		});
 		return res.status(200).json({
 			requestId: mintTx.hash,
 		});
 	} catch (err) {
-		console.error("Unable to mint PKP for user", { err });
+		console.error("Unable to mint PKP for given Google account", { err });
 		return res.status(500).json({
-			error: "Unable to mint PKP for user",
+			error: "Unable to mint PKP for given Google account",
 		});
 	}
 }
 
+// Fetch PKPs for verified Google account
 export async function googleOAuthVerifyToFetchPKPsHandler(
 	req: Request<
 		{},
@@ -90,13 +96,13 @@ export async function googleOAuthVerifyToFetchPKPsHandler(
 	let tokenPayload: TokenPayload | null = null;
 	try {
 		tokenPayload = await verifyIDToken(idToken);
-		console.info("Successfully verified user", {
+		console.info("Successfully verified Google account", {
 			userId: tokenPayload.sub,
 		});
 	} catch (err) {
-		console.error("Unable to verify Google idToken", { err });
+		console.error("Unable to verify Google account", { err });
 		return res.status(400).json({
-			error: "Unable to verify Google idToken",
+			error: "Unable to verify Google account",
 		});
 	}
 
@@ -109,13 +115,16 @@ export async function googleOAuthVerifyToFetchPKPsHandler(
 			authMethodType: AuthMethodType.GoogleJwt,
 			idForAuthMethod,
 		});
+		console.info("Fetched PKPs with Google auth", {
+			pkps: pkps,
+		});
 		return res.status(200).json({
 			pkps: pkps,
 		});
 	} catch (err) {
-		console.error("Unable to mint PKP for user", { err });
+		console.error("Unable to fetch PKPs for given Google account", { err });
 		return res.status(500).json({
-			error: "Unable to mint PKP for user",
+			error: "Unable to fetch PKPs for given Google account",
 		});
 	}
 }

--- a/routes/auth/status.ts
+++ b/routes/auth/status.ts
@@ -61,6 +61,7 @@ export async function getAuthStatusHandler(
 
 		return res.status(200).json({
 			status: AuthStatus.Succeeded,
+			pkpTokenId: tokenIdFromEvent,
 			pkpEthAddress,
 			pkpPublicKey,
 		});

--- a/routes/auth/wallet.ts
+++ b/routes/auth/wallet.ts
@@ -1,0 +1,98 @@
+import { Request } from "express";
+import { Response } from "express-serve-static-core";
+import { ParsedQs } from "qs";
+import {
+	AuthMethodType,
+	AuthSig,
+	AuthMethodVerifyToMintResponse,
+	AuthMethodVerifyToFetchResponse,
+} from "../../models";
+import { utils } from "ethers";
+import { mintPKP, getPKPsForAuthMethod } from "../../lit";
+
+function verifyAuthSig(authSig: AuthSig): boolean {
+	const recoveredAddr = utils.verifyMessage(
+		authSig.signedMessage,
+		authSig.sig,
+	);
+
+	return recoveredAddr.toLowerCase() === authSig.address.toLowerCase();
+}
+
+export async function walletVerifyToMintHandler(
+	req: Request<
+		{},
+		AuthMethodVerifyToMintResponse,
+		AuthSig,
+		ParsedQs,
+		Record<string, any>
+	>,
+	res: Response<AuthMethodVerifyToMintResponse, Record<string, any>, number>,
+) {
+	// get wallet auth sig from body
+	const authSig = req.body;
+
+	// verify access token by fetching user info
+	const verified: boolean = verifyAuthSig(authSig);
+	if (!verified) {
+		return res.status(400).json({
+			error: "Unable to verify auth sig",
+		});
+	}
+
+	// mint PKP for user
+	try {
+		const idForAuthMethod = authSig.address;
+		const mintTx = await mintPKP({
+			authMethodType: AuthMethodType.EthWallet,
+			idForAuthMethod,
+		});
+		return res.status(200).json({
+			requestId: mintTx.hash,
+		});
+	} catch (err) {
+		console.error("Unable to mint PKP for user", { err });
+		return res.status(500).json({
+			error: "Unable to mint PKP for user",
+		});
+	}
+}
+
+export async function walletVerifyToFetchHandler(
+	req: Request<
+		{},
+		AuthMethodVerifyToFetchResponse,
+		AuthSig,
+		ParsedQs,
+		Record<string, any>
+	>,
+	res: Response<AuthMethodVerifyToFetchResponse, Record<string, any>, number>,
+) {
+	// get auth sig from body
+	const authSig = req.body;
+
+	// verify access token by fetching user info
+	const verified: boolean = verifyAuthSig(authSig);
+	if (!verified) {
+		return res.status(400).json({
+			error: "Unable to verify auth sig",
+		});
+	}
+
+	// fetch PKP for user
+	try {
+		const idForAuthMethod = authSig.address;
+		const pkps = await getPKPsForAuthMethod({
+			authMethodType: AuthMethodType.EthWallet,
+			idForAuthMethod,
+		});
+		return res.status(200).json({
+			pkps: pkps,
+		});
+	} catch (err) {
+		console.error("Unable to mint PKP for user", { err });
+		return res.status(500).json({
+			error: "Unable to mint PKP for user",
+		});
+	}
+}

--- a/routes/auth/wallet.ts
+++ b/routes/auth/wallet.ts
@@ -10,6 +10,7 @@ import {
 import { utils } from "ethers";
 import { mintPKP, getPKPsForAuthMethod } from "../../lit";
 
+// Check that the message has been signed by the given address
 function verifyAuthSig(authSig: AuthSig): boolean {
 	const recoveredAddr = utils.verifyMessage(
 		authSig.signedMessage,
@@ -19,6 +20,7 @@ function verifyAuthSig(authSig: AuthSig): boolean {
 	return recoveredAddr.toLowerCase() === authSig.address.toLowerCase();
 }
 
+// Mint PKP for verified Eth wallet
 export async function walletVerifyToMintHandler(
 	req: Request<
 		{},
@@ -32,11 +34,18 @@ export async function walletVerifyToMintHandler(
 	// get wallet auth sig from body
 	const authSig = req.body;
 
-	// verify access token by fetching user info
+	// verify auth sig
 	const verified: boolean = verifyAuthSig(authSig);
-	if (!verified) {
+	if (verified) {
+		console.info("Successfully verified authentication signature", {
+			address: authSig.address,
+		});
+	} else {
+		console.error("Unable to verify authentication signature", {
+			address: authSig.address,
+		});
 		return res.status(400).json({
-			error: "Unable to verify auth sig",
+			error: "Unable to verify authentication signature",
 		});
 	}
 
@@ -47,18 +56,22 @@ export async function walletVerifyToMintHandler(
 			authMethodType: AuthMethodType.EthWallet,
 			idForAuthMethod,
 		});
+		console.info("Minting PKP with Eth wallet", {
+			requestId: mintTx.hash,
+		});
 		return res.status(200).json({
 			requestId: mintTx.hash,
 		});
 	} catch (err) {
-		console.error("Unable to mint PKP for user", { err });
+		console.error("Unable to mint PKP for given Eth wallet", { err });
 		return res.status(500).json({
-			error: "Unable to mint PKP for user",
+			error: "Unable to mint PKP for given Eth wallet",
 		});
 	}
 }
 
-export async function walletVerifyToFetchHandler(
+// Fetch PKPs for verified Eth wallet
+export async function walletVerifyToFetchPKPsHandler(
 	req: Request<
 		{},
 		AuthMethodVerifyToFetchResponse,
@@ -71,11 +84,18 @@ export async function walletVerifyToFetchHandler(
 	// get auth sig from body
 	const authSig = req.body;
 
-	// verify access token by fetching user info
+	// verify auth sig
 	const verified: boolean = verifyAuthSig(authSig);
-	if (!verified) {
+	if (verified) {
+		console.info("Successfully verified authentication signature", {
+			address: authSig.address,
+		});
+	} else {
+		console.error("Unable to verify authentication signature", {
+			address: authSig.address,
+		});
 		return res.status(400).json({
-			error: "Unable to verify auth sig",
+			error: "Unable to verify authentication signature",
 		});
 	}
 
@@ -86,13 +106,16 @@ export async function walletVerifyToFetchHandler(
 			authMethodType: AuthMethodType.EthWallet,
 			idForAuthMethod,
 		});
+		console.info("Fetched PKPs with Eth wallet", {
+			pkps: pkps,
+		});
 		return res.status(200).json({
 			pkps: pkps,
 		});
 	} catch (err) {
-		console.error("Unable to mint PKP for user", { err });
+		console.error("Unable to fetch PKPs for given Eth wallet", { err });
 		return res.status(500).json({
-			error: "Unable to mint PKP for user",
+			error: "Unable to fetch PKPs for given Eth wallet",
 		});
 	}
 }

--- a/routes/middlewares/apiKeyGateAndTracking.ts
+++ b/routes/middlewares/apiKeyGateAndTracking.ts
@@ -1,0 +1,27 @@
+import { NextFunction, Request } from "express";
+import { Response } from "express-serve-static-core";
+import { ParsedQs } from "qs";
+import redisClient from "../../lib/redisClient";
+
+const API_KEY_HEADER_KEY = "api-key";
+
+export default function apiKeyGateAndTracking(
+	req: Request<{}, any, any, ParsedQs, Record<string, any>>,
+	res: Response<any, Record<string, any>, number>,
+	next: NextFunction,
+) {
+	const apiKey = req.header(API_KEY_HEADER_KEY);
+
+	if (!apiKey) {
+		return res.status(400).json({
+			error: "Missing API key. If you do not have one, please request one at https://forms.gle/osJfmRR2PuZ46Xf98",
+		});
+	}
+
+	// increment tracking
+	const now = new Date();
+	const trackingKey = `${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDate()}:${apiKey}`;
+	redisClient.incr(trackingKey);
+
+	next();
+}

--- a/routes/middlewares/limiter.ts
+++ b/routes/middlewares/limiter.ts
@@ -1,22 +1,6 @@
-import config from "../../config";
-
-import * as redis from "redis";
 import rateLimit from "express-rate-limit";
 import RedisStore from "rate-limit-redis";
-
-let redisClient: any;
-
-(async () => {
-	redisClient = redis.createClient({
-		url: config.redisUrl,
-	});
-
-	redisClient.on("error", (error: Error) =>
-		console.error(`Error : ${error}`),
-	);
-
-	await redisClient.connect();
-})();
+import redisClient from "../../lib/redisClient";
 
 const limiter = rateLimit({
 	// Redis store configuration


### PR DESCRIPTION
**Summary**
- Added minting of PKPs using Discord, Eth Wallet as auth methods
- Enable fetching of PKPs that use Google, Discord, and/or Eth Wallet as auth methods
- Included supported endpoints so far in the README

Note: Comparing the current branch to `hwrdtm/implement-webauthn...` since the current branch was created off of it
Note 2: The current branch includes api key update from `main` branch