### PR TITLE
Add unified endpoint for mintNextAndAddAuthMethod

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -49,9 +49,21 @@ import {
 	walletVerifyToMintHandler,
 	walletVerifyToFetchPKPsHandler,
 } from "./routes/auth/wallet";
+
+import {
+	fetchPKPsHandler,
+	mintNextAndAddAuthMethodsHandler,
+} from "./routes/auth/mintAndFetch";
+
 import config from "./config";
-import { stytchOtpVerifyToFetchPKPsHandler, stytchOtpVerifyToMintHandler } from "./routes/auth/stytchOtp";
-import { otpVerifyToFetchPKPsHandler, otpVerifyToMintHandler } from "./routes/auth/otp";
+import {
+	stytchOtpVerifyToFetchPKPsHandler,
+	stytchOtpVerifyToMintHandler,
+} from "./routes/auth/stytchOtp";
+import {
+	otpVerifyToFetchPKPsHandler,
+	otpVerifyToMintHandler,
+} from "./routes/auth/otp";
 
 const app = express();
 
@@ -194,11 +206,12 @@ app.get("/generate-authentication-options", (req, res) => {
 	res.send(options);
 });
 
-
 // --- Store condition
 app.post("/store-condition", storeConditionHandler);
 
 // --- Mint PKP for authorized account
+app.post("/mint-next-and-add-auth-methods", mintNextAndAddAuthMethodsHandler);
+
 app.post("/auth/google", googleOAuthVerifyToMintHandler);
 app.post("/auth/discord", discordOAuthVerifyToMintHandler);
 app.post("/auth/wallet", walletVerifyToMintHandler);

--- a/lit.ts
+++ b/lit.ts
@@ -99,6 +99,52 @@ export async function storeConditionWithSigner(
 	return tx;
 }
 
+export async function mintPKPV2({
+	keyType,
+	permittedAuthMethodTypes,
+	permittedAuthMethodIds,
+	permittedAuthMethodPubkeys,
+	permittedAuthMethodScopes,
+	addPkpEthAddressAsPermittedAddress,
+	sendPkpToItself,
+}: {
+	keyType: string;
+	permittedAuthMethodTypes: string[];
+	permittedAuthMethodIds: string[];
+	permittedAuthMethodPubkeys: string[];
+	permittedAuthMethodScopes: string[][];
+	addPkpEthAddressAsPermittedAddress: boolean;
+	sendPkpToItself: boolean;
+}): Promise<ethers.Transaction> {
+	console.log(
+		"In mintPKPV2",
+		keyType,
+		permittedAuthMethodTypes,
+		permittedAuthMethodIds,
+		permittedAuthMethodPubkeys,
+		permittedAuthMethodScopes,
+		addPkpEthAddressAsPermittedAddress,
+		sendPkpToItself,
+	);
+	const pkpHelper = getPkpHelperContract();
+	const pkpNft = getPkpNftContract();
+
+	// first get mint cost
+	const mintCost = await pkpNft.mintCost();
+	const tx = await pkpHelper.mintNextAndAddAuthMethods(
+		keyType,
+		permittedAuthMethodTypes,
+		permittedAuthMethodIds,
+		permittedAuthMethodPubkeys,
+		permittedAuthMethodScopes,
+		addPkpEthAddressAsPermittedAddress,
+		sendPkpToItself,
+		{ value: mintCost },
+	);
+	console.log("tx", tx);
+	return tx;
+}
+
 export async function mintPKP({
 	authMethodType,
 	authMethodId,

--- a/models/index.ts
+++ b/models/index.ts
@@ -12,6 +12,25 @@ export interface OTPAuthVerifyRegistrationRequest {
 	accessToken: string;
 }
 
+export interface MintNextAndAddAuthMethodsRequest {
+	keyType: string;
+	permittedAuthMethodTypes: string[];
+	permittedAuthMethodIds: string[];
+	permittedAuthMethodPubkeys: string[];
+	permittedAuthMethodScopes: string[][];
+	addPkpEthAddressAsPermittedAddress: boolean;
+	sendPkpToItself: boolean;
+}
+
+export interface MintNextAndAddAuthMethodsResponse
+	extends AuthMethodVerifyRegistrationResponse {}
+
+export interface FetchRequest {
+	authMethodId: string;
+	authMethodType: number;
+	authMethodPubKey?: string;
+}
+
 export interface AuthMethodVerifyRegistrationResponse {
 	requestId?: string;
 	error?: string;
@@ -60,8 +79,8 @@ export interface StoreConditionResponse {
 }
 
 export interface OtpVerificationPayload {
-	userId: string,
-	status: boolean,
+	userId: string;
+	status: boolean;
 }
 
 export interface StoreConditionWithSigner {
@@ -127,9 +146,8 @@ export enum AuthMethodType {
 	Google,
 	GoogleJwt,
 	OTP,
-	StytchOtp = 9
+	StytchOtp = 9,
 }
-
 
 export interface PKP {
 	tokenId: string;

--- a/routes/auth/mintAndFetch.ts
+++ b/routes/auth/mintAndFetch.ts
@@ -1,0 +1,81 @@
+import { Request } from "express";
+import { Response } from "express-serve-static-core";
+import { ParsedQs } from "qs";
+import { getPKPsForAuthMethod, mintPKPV2 } from "../../lit";
+import {
+	AuthMethodVerifyToFetchResponse,
+	FetchRequest,
+	MintNextAndAddAuthMethodsRequest,
+	MintNextAndAddAuthMethodsResponse,
+} from "../../models";
+
+export async function mintNextAndAddAuthMethodsHandler(
+	req: Request<
+		{},
+		MintNextAndAddAuthMethodsResponse,
+		MintNextAndAddAuthMethodsRequest,
+		ParsedQs,
+		Record<string, any>
+	>,
+	res: Response<
+		MintNextAndAddAuthMethodsResponse,
+		Record<string, any>,
+		number
+	>,
+) {
+	// mint PKP for user
+	try {
+		const mintTx = await mintPKPV2(req.body);
+		console.info("Minted PKP", {
+			requestId: mintTx.hash,
+		});
+		return res.status(200).json({
+			requestId: mintTx.hash,
+		});
+	} catch (err) {
+		console.error("Unable to mint PKP", {
+			err,
+		});
+		return res.status(500).json({
+			error: `Unable to mint PKP`,
+		});
+	}
+}
+
+// Fetch PKPs for verified Discord account
+export async function fetchPKPsHandler(
+	req: Request<
+		{},
+		AuthMethodVerifyToFetchResponse,
+		FetchRequest,
+		ParsedQs,
+		Record<string, any>
+	>,
+	res: Response<AuthMethodVerifyToFetchResponse, Record<string, any>, number>,
+) {
+	// get Discord access token from body
+	const { authMethodType, authMethodId } = req.body;
+
+	try {
+		const pkps = await getPKPsForAuthMethod({
+			authMethodType: authMethodType,
+			idForAuthMethod: authMethodId,
+		});
+		console.info("Fetched PKPs with auth type", authMethodType, {
+			pkps: pkps,
+		});
+		return res.status(200).json({
+			pkps: pkps,
+		});
+	} catch (err) {
+		console.error(
+			`Unable to fetch PKPs for given auth type ${authMethodType}`,
+			{
+				err,
+			},
+		);
+		return res.status(500).json({
+			error: `Unable to fetch PKPs for given auth method type: ${authMethodType}`,
+		});
+	}
+}


### PR DESCRIPTION
# What

Related LIT-462.
Closes LIT-978.

This PR:
- Adds a new endpoint that is a thin wrapper around the `PKPHelper.mintNextAndAddAuthMethod` method. This endpoint does not contain any verification logic and also achieves LIT-462.
  - The reason why we are not removing the other endpoints is for backwards compatibility reasons. We will give our community time to migrate to using the new endpoint, as well as time for ourselves to integrate the new endpoint into our SDK (lit-auth-client etc.). Once adoption of the new endpoint has sufficiently increased and stabilized, we can then remove the old endpoint. 

# Testing

Manually tested with the following payload, works.

```json
{
    "keyType": "2",
    "permittedAuthMethodTypes": ["6"],
    "permittedAuthMethodIds": ["0xf8b187ef830fd0d8511177bd550f158b975cc2b82e55e2e568de3fd9c6532682"],
    "permittedAuthMethodPubkeys": ["0x"],
    "permittedAuthMethodScopes": [[0]],
    "addPkpEthAddressAsPermittedAddress": true,
    "sendPkpToItself": false
}
```