### PR TITLE
Feature/lit 1308 relay server fix get account api

### DIFF
--- a/lit.ts
+++ b/lit.ts
@@ -26,7 +26,7 @@ function getContract(abiPath: string, deployedContractAddress: string) {
 	const contractJson = JSON.parse(fs.readFileSync(abiPath, "utf8"));
 	const ethersContract = new ethers.Contract(
 		deployedContractAddress,
-		contractJson,
+		contractJson.abi,
 		signer,
 	);
 	return ethersContract;


### PR DESCRIPTION
Fix: "abi.map is not a function" when passing abi to "new ethers.Contract"