### PR TITLE
Feat/habanero manzano

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Staging instance of the relay server is live at https://relay-server-staging.her
 
 </br>
 
-### Storing Conditions
+### Storing Conditions (only available on Serrano and Cayenne)
 
 | HTTP Verb | Path             | Description                          |
 | --------- | ---------------- | ------------------------------------ |

--- a/lit.ts
+++ b/lit.ts
@@ -16,8 +16,7 @@ async function getContractFromWorker(network: 'manzano' | 'habanero', contractNa
 	const contractsDataRes = await fetch(network === 'manzano' ? MANZANO_CONTRACT_ADDRESSES : HABANERO_CONTRACT_ADDRESSES);
 	const contractList = (await contractsDataRes.json()).data;
 
-	const foundContractNames = contractList.map((contract: any) => contract.name);
-	console.log(`Found contracts for '${contractName}' in ${network}: '${foundContractNames.join("', '")}'`);
+	console.log(`Attempting to get contract "${contractName} from "${network}"`);
 
 	// find object where name is == contractName
 	const contractData = contractList.find((contract: any) => contract.name === contractName);
@@ -27,13 +26,13 @@ async function getContractFromWorker(network: 'manzano' | 'habanero', contractNa
 		throw new Error(`No contract found with name ${contractName}`);
 	}
 
-	const contractAddress = contractData.address_hash;
-	const jsonAbi = contractData.contracts[0].ABI;
+	const contract = contractData.contracts[0];
+	console.log(`Received contract "${contractName} from "${network}"`);
 
 	// -- ethers contract
 	const ethersContract = new ethers.Contract(
-		contractAddress,
-		jsonAbi,
+		contract.address_hash,
+		contract.ABI,
 		signer,
 	);
 
@@ -245,6 +244,9 @@ export async function mintPKPV2({
 		addPkpEthAddressAsPermittedAddress,
 		sendPkpToItself,
 	);
+
+	console.log('config.network:', config.network);
+
 	const pkpHelper = await getPkpHelperContract();
 	const pkpNft = await getPkpNftContract();
 

--- a/lit.ts
+++ b/lit.ts
@@ -27,7 +27,7 @@ async function getContractFromWorker(network: 'manzano' | 'habanero', contractNa
 	}
 
 	const contract = contractData.contracts[0];
-	console.log(`Received contract "${contractName} from "${network}"`);
+	console.log(`Contract address: ${contract.address_hash}"`);
 
 	// -- ethers contract
 	const ethersContract = new ethers.Contract(

--- a/models/index.ts
+++ b/models/index.ts
@@ -141,7 +141,7 @@ export interface Config {
 	serranoContract?: Contract,
 	cayenneContracts?: Contract,
 	useSoloNet: boolean;
-	network: "serrano" | "cayenne";
+	network: "serrano" | "cayenne" | 'manzano' | 'habanero';
 }
 
 export enum CapabilityProtocolPrefix {


### PR DESCRIPTION
# Description

Added support for manzano and habanero networks. They are both published to Render.com under the `lit-relayer` project:

<img width="1370" alt="image" src="https://github.com/LIT-Protocol/relay-server/assets/4049673/b6e8fa82-bd8e-456e-97a1-1d3fb363e60a">

Using the same shared environment group `lit-relayer` with the following keys
<img width="299" alt="image" src="https://github.com/LIT-Protocol/relay-server/assets/4049673/8fbe9c67-bdd0-4681-9f86-507d2d5bbd49">

The only environment variable needs to be change on the service is the `NETWORK` key

<img width="1078" alt="image" src="https://github.com/LIT-Protocol/relay-server/assets/4049673/e8326caa-900d-4e17-b1b9-a1e456f7ca9b">



## Manzano endpoint:
`https://manzano-relayer.getlit.dev`

## Habanero endpoint:
`https://habanero-relayer.getlit.dev`

## Example usage:

```
const litAuthClient = new LitAuthClient({
  litNodeClient,
  litRelayConfig: {
    relayUrl: 'https://habanero-relayer.getlit.dev',
    relayApiKey: '...',
  },
  debug: true,
});
```

# E2E test added:
https://github.com/LIT-Protocol/js-sdk/pull/333