### PR TITLE
use app id from token in discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Staging instance of the relay server is live at https://relay-server-staging.her
 
 </br>
 
-### Storing Conditions
+### Storing Conditions (only available on Serrano and Cayenne)
 
 | HTTP Verb | Path             | Description                          |
 | --------- | ---------------- | ------------------------------------ |

--- a/lit.ts
+++ b/lit.ts
@@ -8,6 +8,38 @@ import { Sequencer } from "./lib/sequencer";
 import { SiweMessage } from "siwe";
 import { toUtf8Bytes } from "ethers/lib/utils";
 
+const MANZANO_CONTRACT_ADDRESSES = 'https://lit-general-worker.getlit.dev/manzano-contract-addresses';
+const HABANERO_CONTRACT_ADDRESSES = 'https://lit-general-worker.getlit.dev/habanero-contract-addresses';
+
+async function getContractFromWorker(network: 'manzano' | 'habanero', contractName: string) {
+	const signer = getSigner();
+	const contractsDataRes = await fetch(network === 'manzano' ? MANZANO_CONTRACT_ADDRESSES : HABANERO_CONTRACT_ADDRESSES);
+	const contractList = (await contractsDataRes.json()).data;
+
+	console.log(`Attempting to get contract "${contractName} from "${network}"`);
+
+	// find object where name is == contractName
+	const contractData = contractList.find((contract: any) => contract.name === contractName);
+
+	// -- validate
+	if (!contractData) {
+		throw new Error(`No contract found with name ${contractName}`);
+	}
+
+	const contract = contractData.contracts[0];
+	console.log(`Contract address: ${contract.address_hash}"`);
+
+	// -- ethers contract
+	const ethersContract = new ethers.Contract(
+		contract.address_hash,
+		contract.ABI,
+		signer,
+	);
+
+	return ethersContract;
+
+}
+
 export function getProvider() {
 	return new ethers.providers.JsonRpcProvider(
 		process.env.LIT_TXSENDER_RPC_URL,
@@ -87,22 +119,27 @@ function getPkpNftContractAbiPath() {
 	}
 }
 
-function getPkpHelperContract() {
+async function getPkpHelperContract() {
 	switch (config.network) {
 		case "serrano":
+
 			return getContract(
-				getPkpHelperContractAbiPath(),
+				getPkpHelperContractAbiPath()!,
 				config?.serranoContract?.pkpHelperAddress as string,
 			);
 		case "cayenne":
 			return getContract(
-				getPkpHelperContractAbiPath(),
+				getPkpHelperContractAbiPath()!,
 				config?.cayenneContracts?.pkpHelperAddress as string,
 			);
+		case "manzano":
+			return getContractFromWorker('manzano', 'PKPHelper');
+		case "habanero":
+			return getContractFromWorker('habanero', 'PKPHelper');
 	}
 }
 
-function getPermissionsContract() {
+async function getPermissionsContract() {
 	switch (config.network) {
 		case "serrano":
 			return getContract(
@@ -114,21 +151,29 @@ function getPermissionsContract() {
 				"./contracts/cayenne/PKPPermissions.json",
 				config?.cayenneContracts?.pkpPermissionsAddress as string,
 			);
+		case "manzano":
+			return getContractFromWorker('manzano', 'PKPPermissions');
+		case "habanero":
+			return getContractFromWorker('habanero', 'PKPPermissions');
 	}
 }
 
-function getPkpNftContract() {
+async function getPkpNftContract() {
 	switch (config.network) {
 		case "serrano":
 			return getContract(
-				getPkpNftContractAbiPath(),
+				getPkpNftContractAbiPath()!,
 				config?.serranoContract?.pkpNftAddress as string,
 			);
 		case "cayenne":
 			return getContract(
-				getPkpNftContractAbiPath(),
+				getPkpNftContractAbiPath()!,
 				config?.cayenneContracts?.pkpNftAddress as string,
 			);
+		case "manzano":
+			return await getContractFromWorker('manzano', 'PKPNFT');
+		case "habanero":
+			return await getContractFromWorker('habanero', 'PKPNFT');
 	}
 }
 
@@ -140,12 +185,12 @@ function prependHexPrefixIfNeeded(hexStr: string) {
 }
 
 export async function getPkpEthAddress(tokenId: string) {
-	const pkpNft = getPkpNftContract();
-	return pkpNft.getEthAddress(tokenId);
+	const pkpNft = await getPkpNftContract();
+	return pkpNft.getEthAddress(tokenId)!;
 }
 
 export async function getPkpPublicKey(tokenId: string) {
-	const pkpNft = getPkpNftContract();
+	const pkpNft = await getPkpNftContract();
 	return pkpNft.getPubkey(tokenId);
 }
 
@@ -160,7 +205,7 @@ export async function storeConditionWithSigner(
 ): Promise<ethers.Transaction> {
 	console.log("Storing condition");
 	const accessControlConditions = getAccessControlConditionsContract();
-	const tx = await accessControlConditions.storeConditionWithSigner(
+	const tx = accessControlConditions?.storeConditionWithSigner(
 		prependHexPrefixIfNeeded(storeConditionRequest.key),
 		prependHexPrefixIfNeeded(storeConditionRequest.value),
 		prependHexPrefixIfNeeded(storeConditionRequest.securityHash),
@@ -199,8 +244,11 @@ export async function mintPKPV2({
 		addPkpEthAddressAsPermittedAddress,
 		sendPkpToItself,
 	);
-	const pkpHelper = getPkpHelperContract();
-	const pkpNft = getPkpNftContract();
+
+	console.log('config.network:', config.network);
+
+	const pkpHelper = await getPkpHelperContract();
+	const pkpNft = await getPkpNftContract();
 
 	// first get mint cost
 	const mintCost = await pkpNft.mintCost();
@@ -228,8 +276,8 @@ export async function mintPKP({
 	authMethodPubkey: string;
 }): Promise<ethers.Transaction> {
 	console.log("in mintPKP");
-	const pkpHelper = getPkpHelperContract();
-	const pkpNft = getPkpNftContract();
+	const pkpHelper = await getPkpHelperContract();
+	const pkpNft = await getPkpNftContract();
 
 	// first get mint cost
 	const mintCost = await pkpNft.mintCost();
@@ -303,10 +351,10 @@ export async function claimPKP({
 	authMethodType: AuthMethodType;
 	authMethodId: string;
 	authMethodPubkey: string;
-}): Promise<ethers.ContractReceipt> {
+}): Promise<ethers.Transaction> {
 	console.log("in claimPKP");
-	const pkpHelper = getPkpHelperContract();
-	const pkpNft = getPkpNftContract();
+	const pkpHelper = await getPkpHelperContract();
+	const pkpNft = await getPkpNftContract();
 
 	// first get mint cost
 	const mintCost = await pkpNft.mintCost();
@@ -387,7 +435,7 @@ export async function getPKPsForAuthMethod({
 		);
 	}
 
-	const pkpPermissions = getPermissionsContract();
+	const pkpPermissions = await getPermissionsContract();
 	if (pkpPermissions) {
 		try {
 			const tokenIds = await pkpPermissions.getTokenIdsForAuthMethod(
@@ -422,7 +470,7 @@ export async function getPubkeyForAuthMethod({
 	authMethodType: AuthMethodType;
 	authMethodId: string;
 }): Promise<string> {
-	const permissionsContract = getPermissionsContract();
+	const permissionsContract = await getPermissionsContract();
 	const pubkey = permissionsContract.getUserPubkeyForAuthMethod(
 		authMethodType,
 		authMethodId,

--- a/models/index.ts
+++ b/models/index.ts
@@ -141,7 +141,7 @@ export interface Config {
 	serranoContract?: Contract,
 	cayenneContracts?: Contract,
 	useSoloNet: boolean;
-	network: "serrano" | "cayenne";
+	network: "serrano" | "cayenne" | 'manzano' | 'habanero';
 }
 
 export enum CapabilityProtocolPrefix {

--- a/models/index.ts
+++ b/models/index.ts
@@ -26,7 +26,7 @@ export interface MintNextAndAddAuthMethodsRequest {
 export interface Claim {
 	derivedKeyId: string;
 	signatures: ethers.Signature[];
-	pubkey:string;
+	pubkey: string;
 	authMethodType: number;
 }
 
@@ -34,7 +34,7 @@ export interface ClaimAndMintResponse {
 	tx: string;
 }
 export interface MintNextAndAddAuthMethodsResponse
-	extends AuthMethodVerifyRegistrationResponse {}
+	extends AuthMethodVerifyRegistrationResponse { }
 
 export interface FetchRequest {
 	authMethodId: string;
@@ -170,4 +170,9 @@ export interface PKP {
 	tokenId: string;
 	publicKey: string;
 	ethAddress: string;
+}
+
+export interface ResolvedAuthMethod {
+	appId: string;
+	userId: string;
 }

--- a/routes/auth/claim.ts
+++ b/routes/auth/claim.ts
@@ -33,10 +33,10 @@ export async function mintClaimedKeyId(
 			authMethodPubkey: "0x",
 		});
 		console.info("claimed key id: transaction hash (request id): ", {
-			requestId: mintTx.transactionHash,
+			requestId: mintTx.hash
 		});
 		return res.status(200).json({
-			requestId: mintTx.transactionHash,
+			requestId: mintTx.hash
 		});
 	} catch (e) {
 		console.error("Unable to claim key with key id: ", derivedKeyId, e);

--- a/routes/auth/webAuthn.ts
+++ b/routes/auth/webAuthn.ts
@@ -1,20 +1,20 @@
 import {
-	generateRegistrationOptions,
-	GenerateRegistrationOptionsOpts,
+  generateRegistrationOptions,
+  GenerateRegistrationOptionsOpts,
 } from "@simplewebauthn/server";
 import { Request } from "express";
 import { Response } from "express-serve-static-core";
 import { ParsedQs } from "qs";
 import {
-	AuthMethodType,
-	AuthMethodVerifyRegistrationResponse,
-	AuthMethodVerifyToFetchResponse,
-	WebAuthnVerifyRegistrationRequest,
+  AuthMethodType,
+  AuthMethodVerifyRegistrationResponse,
+  AuthMethodVerifyToFetchResponse,
+  WebAuthnVerifyRegistrationRequest,
 } from "../../models";
 
 import type {
-	VerifiedRegistrationResponse,
-	VerifyRegistrationResponseOpts,
+  VerifiedRegistrationResponse,
+  VerifyRegistrationResponseOpts,
 } from "@simplewebauthn/server";
 import { verifyRegistrationResponse } from "@simplewebauthn/server";
 
@@ -22,9 +22,9 @@ import { ethers, utils } from "ethers";
 import { hexlify, keccak256, toUtf8Bytes } from "ethers/lib/utils";
 import config from "../../config";
 import {
-	getPKPsForAuthMethod,
-	getPubkeyForAuthMethod,
-	mintPKP,
+  getPKPsForAuthMethod,
+  getPubkeyForAuthMethod,
+  mintPKP,
 } from "../../lit";
 import { getDomainFromUrl } from "../../utils/string";
 
@@ -32,186 +32,186 @@ import { getDomainFromUrl } from "../../utils/string";
  * Generates WebAuthn registration options for a given username.
  */
 export function webAuthnGenerateRegistrationOptionsHandler(
-	req: Request<{}, {}, {}, ParsedQs, Record<string, any>>,
-	res: Response<{}, Record<string, any>, number>,
+  req: Request<{}, {}, {}, ParsedQs, Record<string, any>>,
+  res: Response<{}, Record<string, any>, number>,
 ) {
-	// Get username from query string
-	const username = req.query.username as string | undefined;
+  // Get username from query string
+  const username = req.query.username as string | undefined;
 
-	// Get RP_ID from request Origin.
-	const rpID = getDomainFromUrl(req.get("Origin") || "localhost");
+  // Get RP_ID from request Origin.
+  const rpID = getDomainFromUrl(req.get("Origin") || "localhost");
 
-	const authenticatorUsername = generateUsernameForOptions(username);
-	const opts: GenerateRegistrationOptionsOpts = {
-		rpName: "Lit Protocol",
-		rpID,
-		userID: keccak256(toUtf8Bytes(authenticatorUsername)).slice(2),
-		userName: authenticatorUsername,
-		timeout: 60000,
-		attestationType: "direct", // TODO: change to none
-		authenticatorSelection: {
-			userVerification: "required",
-			residentKey: "required",
-		},
-		supportedAlgorithmIDs: [-7, -257], // ES256 and RS256
-	};
+  const authenticatorUsername = generateUsernameForOptions(username);
+  const opts: GenerateRegistrationOptionsOpts = {
+    rpName: "Lit Protocol",
+    rpID,
+    userID: keccak256(toUtf8Bytes(authenticatorUsername)).slice(2),
+    userName: authenticatorUsername,
+    timeout: 60000,
+    attestationType: "direct", // TODO: change to none
+    authenticatorSelection: {
+      userVerification: "required",
+      residentKey: "required",
+    },
+    supportedAlgorithmIDs: [-7], // ES256
+  };
 
-	const options = generateRegistrationOptions(opts);
+  const options = generateRegistrationOptions(opts);
 
-	return res.json(options);
+  return res.json(options);
 }
 
 export async function webAuthnVerifyRegistrationHandler(
-	req: Request<
-		{},
-		AuthMethodVerifyRegistrationResponse,
-		WebAuthnVerifyRegistrationRequest,
-		ParsedQs,
-		Record<string, any>
-	>,
-	res: Response<
-		AuthMethodVerifyRegistrationResponse,
-		Record<string, any>,
-		number
-	>,
+  req: Request<
+    {},
+    AuthMethodVerifyRegistrationResponse,
+    WebAuthnVerifyRegistrationRequest,
+    ParsedQs,
+    Record<string, any>
+  >,
+  res: Response<
+    AuthMethodVerifyRegistrationResponse,
+    Record<string, any>,
+    number
+  >,
 ) {
-	// Get RP_ID from request Origin.
-	const requestOrigin = req.get("Origin") || "localhost";
-	const rpID = getDomainFromUrl(requestOrigin);
+  // Get RP_ID from request Origin.
+  const requestOrigin = req.get("Origin") || "localhost";
+  const rpID = getDomainFromUrl(requestOrigin);
 
-	// Check if PKP already exists for this credentialRawId.
-	console.log("credentialRawId", req.body.credential.rawId);
+  // Check if PKP already exists for this credentialRawId.
+  console.log("credentialRawId", req.body.credential.rawId);
 
-	const authMethodId = generateAuthMethodId(req.body.credential.rawId);
-	try {
-		const pubKey = await getPubkeyForAuthMethod({
-			authMethodType: AuthMethodType.WebAuthn,
-			authMethodId,
-		});
+  const authMethodId = generateAuthMethodId(req.body.credential.rawId);
+  try {
+    const pubKey = await getPubkeyForAuthMethod({
+      authMethodType: AuthMethodType.WebAuthn,
+      authMethodId,
+    });
 
-		if (pubKey !== "0x" && !ethers.BigNumber.from(pubKey).isZero()) {
-			console.info("PKP already exists for this credential raw ID");
-			return res.status(400).send({
-				error: "PKP already exists for this credential raw ID, please try another one",
-			});
-		}
-	} catch (error) {
-		const _error = error as Error;
-		console.error(_error);
-		return res.status(500).send({
-			error: "Unable to verify if PKP already exists",
-		});
-	}
+    if (pubKey !== "0x" && !ethers.BigNumber.from(pubKey).isZero()) {
+      console.info("PKP already exists for this credential raw ID");
+      return res.status(400).send({
+        error: "PKP already exists for this credential raw ID, please try another one",
+      });
+    }
+  } catch (error) {
+    const _error = error as Error;
+    console.error(_error);
+    return res.status(500).send({
+      error: "Unable to verify if PKP already exists",
+    });
+  }
 
-	// WebAuthn verification.
-	let verification: VerifiedRegistrationResponse;
-	try {
-		const opts: VerifyRegistrationResponseOpts = {
-			credential: req.body.credential,
-			expectedChallenge: () => true, // we don't work with challenges in registration
-			expectedOrigin: [requestOrigin],
-			expectedRPID: rpID,
-			requireUserVerification: true,
-		};
-		verification = await verifyRegistrationResponse(opts);
-	} catch (error) {
-		const _error = error as Error;
-		console.error(_error);
-		return res.status(400).send({ error: _error.message });
-	}
+  // WebAuthn verification.
+  let verification: VerifiedRegistrationResponse;
+  try {
+    const opts: VerifyRegistrationResponseOpts = {
+      credential: req.body.credential,
+      expectedChallenge: () => true, // we don't work with challenges in registration
+      expectedOrigin: [requestOrigin],
+      expectedRPID: rpID,
+      requireUserVerification: true,
+    };
+    verification = await verifyRegistrationResponse(opts);
+  } catch (error) {
+    const _error = error as Error;
+    console.error(_error);
+    return res.status(400).send({ error: _error.message });
+  }
 
-	const { verified, registrationInfo } = verification;
+  const { verified, registrationInfo } = verification;
 
-	// Mint PKP for user.
-	if (!verified || !registrationInfo) {
-		console.error("Unable to verify registration", { verification });
-		return res.status(400).json({
-			error: "Unable to verify registration",
-		});
-	}
+  // Mint PKP for user.
+  if (!verified || !registrationInfo) {
+    console.error("Unable to verify registration", { verification });
+    return res.status(400).json({
+      error: "Unable to verify registration",
+    });
+  }
 
-	const { credentialPublicKey } = registrationInfo;
-	console.log("registrationInfo", { registrationInfo });
+  const { credentialPublicKey } = registrationInfo;
+  console.log("registrationInfo", { registrationInfo });
 
-	try {
-		const cborEncodedCredentialPublicKey = hexlify(
-			utils.arrayify(credentialPublicKey),
-		);
-		console.log("cborEncodedCredentialPublicKey", {
-			cborEncodedCredentialPublicKey,
-		});
+  try {
+    const cborEncodedCredentialPublicKey = hexlify(
+      utils.arrayify(credentialPublicKey),
+    );
+    console.log("cborEncodedCredentialPublicKey", {
+      cborEncodedCredentialPublicKey,
+    });
 
-		const mintTx = await mintPKP({
-			authMethodType: AuthMethodType.WebAuthn,
-			authMethodId,
-			// We want to use the CBOR encoding here to retain as much information as possible
-			// about the COSE (public) key.
-			authMethodPubkey: cborEncodedCredentialPublicKey,
-		});
+    const mintTx = await mintPKP({
+      authMethodType: AuthMethodType.WebAuthn,
+      authMethodId,
+      // We want to use the CBOR encoding here to retain as much information as possible
+      // about the COSE (public) key.
+      authMethodPubkey: cborEncodedCredentialPublicKey,
+    });
 
-		return res.status(200).json({
-			requestId: mintTx.hash,
-		});
-	} catch (error) {
-		const _error = error as Error;
-		console.error("Unable to mint PKP for user", { _error });
-		return res.status(500).json({
-			error: "Unable to mint PKP for user",
-		});
-	}
+    return res.status(200).json({
+      requestId: mintTx.hash,
+    });
+  } catch (error) {
+    const _error = error as Error;
+    console.error("Unable to mint PKP for user", { _error });
+    return res.status(500).json({
+      error: "Unable to mint PKP for user",
+    });
+  }
 }
 
 export async function webAuthnVerifyToFetchPKPsHandler(
-	req: Request<
-		{},
-		AuthMethodVerifyToFetchResponse,
-		any,
-		ParsedQs,
-		Record<string, any>
-	>,
-	res: Response<AuthMethodVerifyToFetchResponse, Record<string, any>, number>,
+  req: Request<
+    {},
+    AuthMethodVerifyToFetchResponse,
+    any,
+    ParsedQs,
+    Record<string, any>
+  >,
+  res: Response<AuthMethodVerifyToFetchResponse, Record<string, any>, number>,
 ) {
-	// Check if PKP already exists for this credentialRawId.
-	console.log("credentialRawId", req.body.rawId);
+  // Check if PKP already exists for this credentialRawId.
+  console.log("credentialRawId", req.body.rawId);
 
-	try {
-		const idForAuthMethod = generateAuthMethodId(req.body.rawId);
+  try {
+    const idForAuthMethod = generateAuthMethodId(req.body.rawId);
 
-		const pkps = await getPKPsForAuthMethod({
-			authMethodType: AuthMethodType.WebAuthn,
-			idForAuthMethod,
-		});
-		console.info("Fetched PKPs with WebAuthn", {
-			pkps: pkps,
-		});
-		return res.status(200).json({
-			pkps: pkps,
-		});
-	} catch (err) {
-		console.error("Unable to fetch PKPs for given WebAuthn", { err });
-		return res.status(500).json({
-			error: "Unable to fetch PKPs for given WebAuthn",
-		});
-	}
+    const pkps = await getPKPsForAuthMethod({
+      authMethodType: AuthMethodType.WebAuthn,
+      idForAuthMethod,
+    });
+    console.info("Fetched PKPs with WebAuthn", {
+      pkps: pkps,
+    });
+    return res.status(200).json({
+      pkps: pkps,
+    });
+  } catch (err) {
+    console.error("Unable to fetch PKPs for given WebAuthn", { err });
+    return res.status(500).json({
+      error: "Unable to fetch PKPs for given WebAuthn",
+    });
+  }
 }
 
 function generateAuthMethodId(credentialRawId: string): string {
-	return utils.keccak256(toUtf8Bytes(`${credentialRawId}:lit`));
+  return utils.keccak256(toUtf8Bytes(`${credentialRawId}:lit`));
 }
 
 // Generate default username given timestamp, using timestamp format YYYY-MM-DD HH:MM:SS)
 function generateDefaultUsername(): string {
-	const date = new Date();
-	const year = date.getFullYear();
-	const month = date.getMonth() + 1;
-	const day = date.getDate();
-	const hours = date.getHours();
-	const minutes = date.getMinutes();
-	const seconds = date.getSeconds();
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  const seconds = date.getSeconds();
 
-	return `Usernameless user (${year}-${month}-${day} ${hours}:${minutes}:${seconds})`;
+  return `Usernameless user (${year}-${month}-${day} ${hours}:${minutes}:${seconds})`;
 }
 
 function generateUsernameForOptions(username?: string): string {
-	return !!username ? username : generateDefaultUsername();
+  return !!username ? username : generateDefaultUsername();
 }


### PR DESCRIPTION
We are currently replacing the app id that was passed in with our own, in the relayer. This breaks how PKP Scoping should work.

This PR removes our static discord app_id and replaces it with the one resolved by the discord access token provided by the user.
