### PR TITLE
feat: add endpoint for PkpHelperV2 contract

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -53,6 +53,7 @@ import {
 import {
 	fetchPKPsHandler,
 	mintNextAndAddAuthMethodsHandler,
+	mintNextAndAddAuthMethodsHandlerV2,
 } from "./routes/auth/mintAndFetch";
 
 import config from "./config";
@@ -213,6 +214,10 @@ app.post("/store-condition", storeConditionHandler);
 
 // --- Mint PKP for authorized account
 app.post("/mint-next-and-add-auth-methods", mintNextAndAddAuthMethodsHandler);
+
+// --- Mint PKP for authorized account using v2 of the helper contract
+app.post("/mint-next-and-add-auth-methods-v2", mintNextAndAddAuthMethodsHandlerV2);
+
 
 // --- Fetch PKPs tied to authorized account
 app.post("/fetch-pkps-by-auth-method", fetchPKPsHandler);

--- a/lit.ts
+++ b/lit.ts
@@ -119,6 +119,19 @@ function getPkpNftContractAbiPath() {
 	}
 }
 
+async function getPkpHelperV2Contract() {
+	// TODO: add support local paths for serrano and cayenne
+
+	switch (config.network) {
+		case "manzano":
+			return getContractFromWorker('manzano', 'PKPHelperV2');
+		case "habanero":
+			return getContractFromWorker('habanero', 'PKPHelperV2');
+	}
+
+	throw new Error("Unsupported network");
+}
+
 async function getPkpHelperContract() {
 	switch (config.network) {
 		case "serrano":
@@ -212,6 +225,61 @@ export async function storeConditionWithSigner(
 		storeConditionRequest.chainId,
 		storeConditionRequest.permanent,
 		utils.getAddress(storeConditionRequest.creatorAddress),
+	);
+	console.log("tx", tx);
+	return tx;
+}
+
+export async function mintPKPV3({
+	keyType,
+	permittedAuthMethodTypes,
+	permittedAuthMethodIds,
+	permittedAuthMethodPubkeys,
+	permittedAuthMethodScopes,
+	addPkpEthAddressAsPermittedAddress,
+	pkpEthAddressScopes,
+	sendPkpToItself,
+	burnPkp,
+}: {
+	keyType: string;
+	permittedAuthMethodTypes: string[];
+	permittedAuthMethodIds: string[];
+	permittedAuthMethodPubkeys: string[];
+	permittedAuthMethodScopes: string[][];
+	addPkpEthAddressAsPermittedAddress: boolean;
+	pkpEthAddressScopes: string[][];
+	sendPkpToItself: boolean;
+	burnPkp: boolean;
+}): Promise<ethers.Transaction> {
+	console.log(
+		"In mintPKPV2",
+		keyType,
+		permittedAuthMethodTypes,
+		permittedAuthMethodIds,
+		permittedAuthMethodPubkeys,
+		permittedAuthMethodScopes,
+		addPkpEthAddressAsPermittedAddress,
+		sendPkpToItself,
+	);
+
+	console.log('config.network:', config.network);
+
+	const pkpHelper = await getPkpHelperV2Contract();
+	const pkpNft = await getPkpNftContract();
+
+	// first get mint cost
+	const mintCost = await pkpNft.mintCost();
+	const tx = await pkpHelper.mintNextAndAddAuthMethods(
+		keyType,
+		permittedAuthMethodTypes,
+		permittedAuthMethodIds,
+		permittedAuthMethodPubkeys,
+		permittedAuthMethodScopes,
+		addPkpEthAddressAsPermittedAddress,
+		pkpEthAddressScopes,
+		sendPkpToItself,
+		burnPkp,
+		{ value: mintCost },
 	);
 	console.log("tx", tx);
 	return tx;

--- a/models/index.ts
+++ b/models/index.ts
@@ -13,6 +13,18 @@ export interface OTPAuthVerifyRegistrationRequest {
 	accessToken: string;
 }
 
+export interface MintNextAndAddAuthMethodsV2Request {
+	keyType: string;
+	permittedAuthMethodTypes: string[];
+	permittedAuthMethodIds: string[];
+	permittedAuthMethodPubkeys: string[];
+	permittedAuthMethodScopes: string[][];
+	addPkpEthAddressAsPermittedAddress: boolean;
+	pkpEthAddressScopes: string[][];
+	sendPkpToItself: boolean;
+	burnPkp: boolean;
+}
+
 export interface MintNextAndAddAuthMethodsRequest {
 	keyType: string;
 	permittedAuthMethodTypes: string[];

--- a/routes/auth/mintAndFetch.ts
+++ b/routes/auth/mintAndFetch.ts
@@ -1,13 +1,47 @@
 import { Request } from "express";
 import { Response } from "express-serve-static-core";
 import { ParsedQs } from "qs";
-import { getPKPsForAuthMethod, mintPKPV2 } from "../../lit";
+import { getPKPsForAuthMethod, mintPKPV2, mintPKPV3 } from "../../lit";
 import {
 	AuthMethodVerifyToFetchResponse,
 	FetchRequest,
 	MintNextAndAddAuthMethodsRequest,
 	MintNextAndAddAuthMethodsResponse,
+	MintNextAndAddAuthMethodsV2Request,
 } from "../../models";
+
+export async function mintNextAndAddAuthMethodsHandlerV2(
+	req: Request<
+		{},
+		MintNextAndAddAuthMethodsResponse,
+		MintNextAndAddAuthMethodsV2Request,
+		ParsedQs,
+		Record<string, any>
+	>,
+	res: Response<
+		MintNextAndAddAuthMethodsResponse,
+		Record<string, any>,
+		number
+	>,
+) {
+	// mint PKP for user
+	try {
+		const mintTx = await mintPKPV3(req.body);
+		console.info("Minted PKP", {
+			requestId: mintTx.hash,
+		});
+		return res.status(200).json({
+			requestId: mintTx.hash,
+		});
+	} catch (err) {
+		console.error("Unable to mint PKP", {
+			err,
+		});
+		return res.status(500).json({
+			error: `Unable to mint PKP`,
+		});
+	}
+}
 
 export async function mintNextAndAddAuthMethodsHandler(
 	req: Request<


### PR DESCRIPTION
# Description

Draft for initial review only, do not merge.

Adds a new endpoint to expose the new mint from PkpHelperV2.

## New endpoint

### Path

```
/mint-next-and-add-auth-methods-v2
```

### Params

```
keyType: string;
permittedAuthMethodTypes: string[];
permittedAuthMethodIds: string[];
permittedAuthMethodPubkeys: string[];
permittedAuthMethodScopes: string[][];
addPkpEthAddressAsPermittedAddress: boolean;
pkpEthAddressScopes: string[][];
sendPkpToItself: boolean;
burnPkp: boolean;
```