### PR TITLE
fixes: normalize endpoints to always return json

### DIFF
--- a/routes/delegate/register.ts
+++ b/routes/delegate/register.ts
@@ -72,7 +72,11 @@ export async function registerPayerHandler(req: Request, res: Response) {
     const apiKey = req.header("api-key");
 
     if (!apiKey) {
-        res.status(400).send("Missing API key");
+        res.status(400).send({
+            success: false,
+            error: "Missing API key"
+        });
+
         return;
     }
     const secret = generatePayerSecret();
@@ -83,13 +87,17 @@ export async function registerPayerHandler(req: Request, res: Response) {
     return fundWallet(wallet)
         .then(createCapacityCredits)
         .then((wallet: Wallet) => {
-            res.status(200).send({
+            res.status(200).json({
+                success: true,
                 payerWalletAddress: wallet.address,
                 payerSecretKey: secret
             });
         })
         .catch((err) => {
             console.error("Failed to register payer", err);
-            res.status(500).send("Failed to register payer");
+            res.status(500).json({
+                success: false,
+                error: err.toString()
+            });
         });
 }

--- a/routes/delegate/user.ts
+++ b/routes/delegate/user.ts
@@ -8,12 +8,19 @@ export async function addPayeeHandler(req: Request, res: Response) {
     const payerSecret = req.header('payer-secret-key');
 
     if (!apiKey || !payerSecret) {
-        res.status(400).send('Missing or invalid API / Payer key');
+        res.status(400).json({
+            success: false,
+            error: 'Missing or invalid API / Payer key'
+        });
+
         return;
     }
 
     if (!payeeAddresses || !Array.isArray(payeeAddresses) || payeeAddresses.length < 1) {
-        res.status(400).send('Missing or invalid payee addresses');
+        res.status(400).json({
+            success: false,
+            error: 'Missing or invalid payee addresses'
+        });
         return;
     }
 
@@ -35,12 +42,12 @@ export async function addPayeeHandler(req: Request, res: Response) {
     }
 
     if (error) {
-        res.status(500).send({
+        res.status(500).json({
             success: false,
             error
         });
     } else {
-        res.status(200).send({
+        res.status(200).json({
             success: true
         });
     }


### PR DESCRIPTION
Replaces endpoint responses that return strings, with ones following the following pattern:

```
{
  success: true,
  [...key: string]: [value: string]
}
|
{
  success: false,
  error: string
}
```