### PR TITLE
Signing Route

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,6 +69,7 @@ import { mintClaimedKeyId } from "./routes/auth/claim";
 import { registerPayerHandler } from "./routes/delegate/register";
 import { addPayeeHandler } from "./routes/delegate/user";
 import { sendTxnHandler } from "./routes/auth/sendTxn";
+import { pkpSignHandler } from "./routes/auth/pkpSign
 
 const app = express();
 
@@ -226,6 +227,9 @@ app.get("/auth/status/:requestId", getAuthStatusHandler);
 // -- Payment Delegation
 app.post("/register-payer", registerPayerHandler);
 app.post("/add-users", addPayeeHandler);
+
+// --- PKP Signing
+app.post("/pkp-sign", pkpSignHandler);
 
 // --- Send TXN
 app.post("/send-txn", sendTxnHandler);

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
-		"@lit-protocol/constants": "^6.2.4",
+		"@lit-protocol/constants": "^7.0.6",
 		"@lit-protocol/contracts": "^0.0.39",
-		"@lit-protocol/lit-node-client-nodejs": "^6.2.4",
+		"@lit-protocol/lit-auth-client": "^7.0.6",
+		"@lit-protocol/lit-node-client-nodejs": "^7.0.6",
+		"@lit-protocol/pkp-ethers": "^7.0.6",
 		"@simplewebauthn/server": "6.2.1",
 		"base64url": "^3.0.1",
 		"cbor": "^8.1.0",

--- a/routes/auth/pkpSign.ts
+++ b/routes/auth/pkpSign.ts
@@ -1,19 +1,20 @@
 import { Request } from "express";
 import { Response } from "express-serve-static-core";
 import { ParsedQs } from "qs";
-import { LitNodeClientNodeJs } from "@lit-protocol/lit-node-client-nodejs";
-import { LitActionResource, LitPKPResource } from "@lit-protocol/auth-helpers";
-import { getSigner } from "../../lit";
-import { LIT_NETWORKS_KEYS } from "@lit-protocol/types";
-import { LIT_ABILITY } from "@lit-protocol/constants";
 import * as ethers from "ethers";
-import { PKPEthersWallet } from "@lit-protocol/pkp-ethers";
 import { Sequencer } from "../../lib/sequencer";
 import {
 	estimateGasWithBalanceOverride,
 	removeTxnSignature,
 	txnToBytesToSign,
 } from "../../utils/eth";
+import {
+	getSigner,
+	initializeLitClient,
+	getPkpSessionSigs,
+	signWithPkp,
+	initializePkpWallet,
+} from "../../lit";
 
 interface PKPSignRequest {
 	toSign: string;
@@ -40,52 +41,27 @@ export async function pkpSignHandler(
 		if (!toSign || !pkpPublicKey || !authMethod) {
 			return res.status(400).json({
 				error: "Missing required parameters: toSign, pkpPublicKey, or authMethod",
-				signature: ""
+				signature: "",
 			});
 		}
 
 		// Initialize and connect to LitNodeClient
-		const litNodeClient = new LitNodeClientNodeJs({
-			litNetwork: process.env.NETWORK as LIT_NETWORKS_KEYS,
-			debug: false
-		});
-		await litNodeClient.connect();
+		const litNodeClient = await initializeLitClient();
 
 		// Get session signatures
-		const sessionSigs = await litNodeClient.getPkpSessionSigs({
-			pkpPublicKey: pkpPublicKey,
-			chain: "ethereum",
-			authMethods: [authMethod],
-			expiration: new Date(Date.now() + 1000 * 60 * 10).toISOString(), // 10 minutes
-			resourceAbilityRequests: [
-			  {
-				resource: new LitActionResource("*"),
-				ability: LIT_ABILITY.LitActionExecution,
-			  },
-			  {
-				resource: new LitPKPResource("*"),
-				ability: LIT_ABILITY.PKPSigning,
-			  },
-			],
-		});
+		const sessionSigs = await getPkpSessionSigs(litNodeClient, pkpPublicKey, authMethod);
 
 		// Use litNodeClient to sign the message
-		const signingResult = await litNodeClient.pkpSign({
-			pubKey: pkpPublicKey,
+		const signingResult = await signWithPkp(
+			litNodeClient,
+			pkpPublicKey,
 			sessionSigs,
-			toSign: ethers.utils.arrayify(ethers.utils.hashMessage(toSign)),
-		});
-
-		if (!signingResult || !signingResult.signature) {
-			throw new Error("Failed to get signature from PKP");
-		}
+			ethers.utils.arrayify(ethers.utils.hashMessage(toSign))
+		);
 
 		// Verify the signature
 		const pkpEthAddress = ethers.utils.computeAddress(pkpPublicKey);
-		const recoveredAddress = ethers.utils.verifyMessage(
-			toSign,
-			signingResult.signature
-		);
+		const recoveredAddress = ethers.utils.verifyMessage(toSign, signingResult.signature);
 
 		if (recoveredAddress.toLowerCase() !== pkpEthAddress.toLowerCase()) {
 			throw new Error("Signature verification failed");
@@ -101,12 +77,13 @@ export async function pkpSignHandler(
 
 				// Parse and fix the transaction
 				const parsedTxn = JSON.parse(toSign);
-				
+
 				// Prevent direct ETH transfers - only allow contract interactions
-				if (parsedTxn.data === undefined || parsedTxn.data === '0x') {
+				if (parsedTxn.data === undefined || parsedTxn.data === "0x") {
 					return res.status(400).json({
-						error: "Direct ETH transfers are not allowed. This endpoint is only for contract interactions.",
-						signature: signingResult.signature
+						error:
+							"Direct ETH transfers are not allowed. This endpoint is only for contract interactions.",
+						signature: signingResult.signature,
 					});
 				}
 
@@ -122,50 +99,44 @@ export async function pkpSignHandler(
 				// First sign the transaction bytes
 				const txnWithoutSig = removeTxnSignature(fixedTxn);
 				const msgBytes = await txnToBytesToSign(txnWithoutSig);
-				
-				// Get a fresh signature for the transaction bytes
-				const txnSigningResult = await litNodeClient.pkpSign({
-					pubKey: pkpPublicKey,
-					sessionSigs,
-					toSign: msgBytes,
-				});
 
-				if (!txnSigningResult || !txnSigningResult.signature) {
-					throw new Error("Failed to get transaction signature from PKP");
-				}
+				// Get a fresh signature for the transaction bytes
+				const txnSigningResult = await signWithPkp(
+					litNodeClient,
+					pkpPublicKey,
+					sessionSigs,
+					msgBytes
+				);
 
 				// Split the signature into components
 				const sig = ethers.utils.splitSignature(txnSigningResult.signature);
-				
+
 				// Verify the signature matches the PKP address
 				const fromViaSignature = ethers.utils.recoverAddress(msgBytes, sig);
-				
+
 				if (fromViaSignature.toLowerCase() !== pkpEthAddress.toLowerCase()) {
 					return res.status(500).json({
-						error: "Invalid signature - the recovered signature does not match the PKP address",
-						signature: signingResult.signature
+						error:
+							"Invalid signature - the recovered signature does not match the PKP address",
+						signature: signingResult.signature,
 					});
 				}
 
 				// Check gas price sanity
 				const currentGasPrice = await provider.getGasPrice();
 				const ALLOWED_GAS_PRICE_DEVIATION_PERCENTAGE = 10;
-				const gasPriceFromClient = ethers.BigNumber.from(fixedTxn.gasPrice);
+				const gasPriceFromClient = fixedTxn.gasPrice;
 				if (
 					gasPriceFromClient.lt(
-						currentGasPrice
-							.mul(100 - ALLOWED_GAS_PRICE_DEVIATION_PERCENTAGE)
-							.div(100),
+						currentGasPrice.mul(100 - ALLOWED_GAS_PRICE_DEVIATION_PERCENTAGE).div(100)
 					) ||
 					gasPriceFromClient.gt(
-						currentGasPrice
-							.mul(100 + ALLOWED_GAS_PRICE_DEVIATION_PERCENTAGE)
-							.div(100),
+						currentGasPrice.mul(100 + ALLOWED_GAS_PRICE_DEVIATION_PERCENTAGE).div(100)
 					)
 				) {
 					return res.status(500).json({
 						error: `Invalid gas price - the gas price sent by the client of ${gasPriceFromClient.toString()} is not within ${ALLOWED_GAS_PRICE_DEVIATION_PERCENTAGE}% of the current gas price of ${currentGasPrice.toString()}`,
-						signature: signingResult.signature
+						signature: signingResult.signature,
 					});
 				}
 
@@ -175,26 +146,22 @@ export async function pkpSignHandler(
 						provider,
 						txn: fixedTxn,
 						walletAddress: pkpEthAddress,
-					}),
+					})
 				);
 
 				const ALLOWED_GAS_LIMIT_DEVIATION_PERCENTAGE = 10;
-				const gasLimitFromClient = ethers.BigNumber.from(fixedTxn.gasLimit);
+				const gasLimitFromClient = fixedTxn.gasLimit;
 				if (
 					gasLimitFromClient.lt(
-						gasLimit
-							.mul(100 - ALLOWED_GAS_LIMIT_DEVIATION_PERCENTAGE)
-							.div(100),
+						gasLimit.mul(100 - ALLOWED_GAS_LIMIT_DEVIATION_PERCENTAGE).div(100)
 					) ||
 					gasLimitFromClient.gt(
-						gasLimit
-							.mul(100 + ALLOWED_GAS_LIMIT_DEVIATION_PERCENTAGE)
-							.div(100),
+						gasLimit.mul(100 + ALLOWED_GAS_LIMIT_DEVIATION_PERCENTAGE).div(100)
 					)
 				) {
 					return res.status(500).json({
 						error: `Invalid gas limit - the gas limit sent by the client of ${gasLimitFromClient.toString()} is not within ${ALLOWED_GAS_LIMIT_DEVIATION_PERCENTAGE}% of the gas limit we estimated of ${gasLimit.toString()}`,
-						signature: signingResult.signature
+						signature: signingResult.signature,
 					});
 				}
 
@@ -202,10 +169,7 @@ export async function pkpSignHandler(
 				const gasToFund = gasLimitFromClient.mul(gasPriceFromClient);
 				const gasFundingTxn = await sequencer.wait({
 					action: (...args) => {
-						const paramsToFn = Object.assign(
-							{},
-							...args,
-						) as ethers.providers.TransactionRequest;
+						const paramsToFn = Object.assign({}, ...args) as ethers.providers.TransactionRequest;
 						return signer.sendTransaction(paramsToFn);
 					},
 					params: [{ to: pkpEthAddress, value: gasToFund }],
@@ -214,13 +178,12 @@ export async function pkpSignHandler(
 				await gasFundingTxn.wait();
 
 				// Initialize PKP wallet for broadcasting
-				const pkpWallet = new PKPEthersWallet({
-					controllerSessionSigs: sessionSigs,
-					pkpPubKey: pkpPublicKey,
+				const pkpWallet = await initializePkpWallet({
+					sessionSigs,
+					pkpPublicKey,
 					litNodeClient,
-					provider
+					provider,
 				});
-				await pkpWallet.init();
 
 				// Broadcast the transaction using PKP wallet
 				const tx = await pkpWallet.sendTransaction({
@@ -230,7 +193,7 @@ export async function pkpSignHandler(
 					gasLimit: gasLimitFromClient,
 					gasPrice: gasPriceFromClient,
 					nonce: fixedTxn.nonce,
-					chainId: fixedTxn.chainId
+					chainId: fixedTxn.chainId,
 				});
 
 				console.info("Successfully signed and sent transaction", {
@@ -251,19 +214,17 @@ export async function pkpSignHandler(
 		console.info("Successfully signed and verified message with PKP", {
 			signature: signingResult.signature,
 			pkpEthAddress,
-			recoveredAddress
+			recoveredAddress,
 		});
 
 		return res.status(200).json({
 			signature: signingResult.signature,
 		});
 	} catch (err) {
-		console.error("[pkpSignHandler] Unable to sign message", {
-			err,
-		});
+		console.error("[pkpSignHandler] Unable to sign message", { err });
 		return res.status(500).json({
 			error: `[pkpSignHandler] Unable to sign message: ${JSON.stringify(err)}`,
-			signature: ""
+			signature: "",
 		});
 	}
 }

--- a/routes/auth/pkpSign.ts
+++ b/routes/auth/pkpSign.ts
@@ -1,0 +1,269 @@
+import { Request } from "express";
+import { Response } from "express-serve-static-core";
+import { ParsedQs } from "qs";
+import { LitNodeClientNodeJs } from "@lit-protocol/lit-node-client-nodejs";
+import { LitActionResource, LitPKPResource } from "@lit-protocol/auth-helpers";
+import { getSigner } from "../../lit";
+import { LIT_NETWORKS_KEYS } from "@lit-protocol/types";
+import { LIT_ABILITY } from "@lit-protocol/constants";
+import * as ethers from "ethers";
+import { PKPEthersWallet } from "@lit-protocol/pkp-ethers";
+import { Sequencer } from "../../lib/sequencer";
+import {
+	estimateGasWithBalanceOverride,
+	removeTxnSignature,
+	txnToBytesToSign,
+} from "../../utils/eth";
+
+interface PKPSignRequest {
+	toSign: string;
+	pkpPublicKey: string;
+	authMethod: any;
+	sendTransaction?: boolean;
+}
+
+interface PKPSignResponse {
+	signature: string;
+	requestId?: string;
+	error?: string;
+}
+
+// Sign a message using PKP
+export async function pkpSignHandler(
+	req: Request<{}, PKPSignResponse, PKPSignRequest, ParsedQs, Record<string, any>>,
+	res: Response<PKPSignResponse, Record<string, any>, number>
+) {
+	try {
+		const { toSign, pkpPublicKey, authMethod, sendTransaction } = req.body;
+
+		// Input validation
+		if (!toSign || !pkpPublicKey || !authMethod) {
+			return res.status(400).json({
+				error: "Missing required parameters: toSign, pkpPublicKey, or authMethod",
+				signature: ""
+			});
+		}
+
+		// Initialize and connect to LitNodeClient
+		const litNodeClient = new LitNodeClientNodeJs({
+			litNetwork: process.env.NETWORK as LIT_NETWORKS_KEYS,
+			debug: false
+		});
+		await litNodeClient.connect();
+
+		// Get session signatures
+		const sessionSigs = await litNodeClient.getPkpSessionSigs({
+			pkpPublicKey: pkpPublicKey,
+			chain: "ethereum",
+			authMethods: [authMethod],
+			expiration: new Date(Date.now() + 1000 * 60 * 10).toISOString(), // 10 minutes
+			resourceAbilityRequests: [
+			  {
+				resource: new LitActionResource("*"),
+				ability: LIT_ABILITY.LitActionExecution,
+			  },
+			  {
+				resource: new LitPKPResource("*"),
+				ability: LIT_ABILITY.PKPSigning,
+			  },
+			],
+		});
+
+		// Use litNodeClient to sign the message
+		const signingResult = await litNodeClient.pkpSign({
+			pubKey: pkpPublicKey,
+			sessionSigs,
+			toSign: ethers.utils.arrayify(ethers.utils.hashMessage(toSign)),
+		});
+
+		if (!signingResult || !signingResult.signature) {
+			throw new Error("Failed to get signature from PKP");
+		}
+
+		// Verify the signature
+		const pkpEthAddress = ethers.utils.computeAddress(pkpPublicKey);
+		const recoveredAddress = ethers.utils.verifyMessage(
+			toSign,
+			signingResult.signature
+		);
+
+		if (recoveredAddress.toLowerCase() !== pkpEthAddress.toLowerCase()) {
+			throw new Error("Signature verification failed");
+		}
+
+		// If sendTransaction is true, handle the transaction
+		if (sendTransaction) {
+			try {
+				const sequencer = Sequencer.Instance;
+				const signer = getSigner();
+				Sequencer.Wallet = signer;
+				const provider = signer.provider as ethers.providers.JsonRpcProvider;
+
+				// Parse and fix the transaction
+				const parsedTxn = JSON.parse(toSign);
+				
+				// Prevent direct ETH transfers - only allow contract interactions
+				if (parsedTxn.data === undefined || parsedTxn.data === '0x') {
+					return res.status(400).json({
+						error: "Direct ETH transfers are not allowed. This endpoint is only for contract interactions.",
+						signature: signingResult.signature
+					});
+				}
+
+				const fixedTxn = {
+					...parsedTxn,
+					gasLimit: ethers.BigNumber.from(parsedTxn.gasLimit),
+					gasPrice: ethers.BigNumber.from(parsedTxn.gasPrice),
+					value: ethers.BigNumber.from(parsedTxn.value),
+					type: parsedTxn.type || undefined,
+					from: pkpEthAddress,
+				};
+
+				// First sign the transaction bytes
+				const txnWithoutSig = removeTxnSignature(fixedTxn);
+				const msgBytes = await txnToBytesToSign(txnWithoutSig);
+				
+				// Get a fresh signature for the transaction bytes
+				const txnSigningResult = await litNodeClient.pkpSign({
+					pubKey: pkpPublicKey,
+					sessionSigs,
+					toSign: msgBytes,
+				});
+
+				if (!txnSigningResult || !txnSigningResult.signature) {
+					throw new Error("Failed to get transaction signature from PKP");
+				}
+
+				// Split the signature into components
+				const sig = ethers.utils.splitSignature(txnSigningResult.signature);
+				
+				// Verify the signature matches the PKP address
+				const fromViaSignature = ethers.utils.recoverAddress(msgBytes, sig);
+				
+				if (fromViaSignature.toLowerCase() !== pkpEthAddress.toLowerCase()) {
+					return res.status(500).json({
+						error: "Invalid signature - the recovered signature does not match the PKP address",
+						signature: signingResult.signature
+					});
+				}
+
+				// Check gas price sanity
+				const currentGasPrice = await provider.getGasPrice();
+				const ALLOWED_GAS_PRICE_DEVIATION_PERCENTAGE = 10;
+				const gasPriceFromClient = ethers.BigNumber.from(fixedTxn.gasPrice);
+				if (
+					gasPriceFromClient.lt(
+						currentGasPrice
+							.mul(100 - ALLOWED_GAS_PRICE_DEVIATION_PERCENTAGE)
+							.div(100),
+					) ||
+					gasPriceFromClient.gt(
+						currentGasPrice
+							.mul(100 + ALLOWED_GAS_PRICE_DEVIATION_PERCENTAGE)
+							.div(100),
+					)
+				) {
+					return res.status(500).json({
+						error: `Invalid gas price - the gas price sent by the client of ${gasPriceFromClient.toString()} is not within ${ALLOWED_GAS_PRICE_DEVIATION_PERCENTAGE}% of the current gas price of ${currentGasPrice.toString()}`,
+						signature: signingResult.signature
+					});
+				}
+
+				// Estimate gas and verify gas limit
+				const gasLimit = ethers.BigNumber.from(
+					await estimateGasWithBalanceOverride({
+						provider,
+						txn: fixedTxn,
+						walletAddress: pkpEthAddress,
+					}),
+				);
+
+				const ALLOWED_GAS_LIMIT_DEVIATION_PERCENTAGE = 10;
+				const gasLimitFromClient = ethers.BigNumber.from(fixedTxn.gasLimit);
+				if (
+					gasLimitFromClient.lt(
+						gasLimit
+							.mul(100 - ALLOWED_GAS_LIMIT_DEVIATION_PERCENTAGE)
+							.div(100),
+					) ||
+					gasLimitFromClient.gt(
+						gasLimit
+							.mul(100 + ALLOWED_GAS_LIMIT_DEVIATION_PERCENTAGE)
+							.div(100),
+					)
+				) {
+					return res.status(500).json({
+						error: `Invalid gas limit - the gas limit sent by the client of ${gasLimitFromClient.toString()} is not within ${ALLOWED_GAS_LIMIT_DEVIATION_PERCENTAGE}% of the gas limit we estimated of ${gasLimit.toString()}`,
+						signature: signingResult.signature
+					});
+				}
+
+				// Calculate and send gas funding
+				const gasToFund = gasLimitFromClient.mul(gasPriceFromClient);
+				const gasFundingTxn = await sequencer.wait({
+					action: (...args) => {
+						const paramsToFn = Object.assign(
+							{},
+							...args,
+						) as ethers.providers.TransactionRequest;
+						return signer.sendTransaction(paramsToFn);
+					},
+					params: [{ to: pkpEthAddress, value: gasToFund }],
+					transactionData: {},
+				});
+				await gasFundingTxn.wait();
+
+				// Initialize PKP wallet for broadcasting
+				const pkpWallet = new PKPEthersWallet({
+					controllerSessionSigs: sessionSigs,
+					pkpPubKey: pkpPublicKey,
+					litNodeClient,
+					provider
+				});
+				await pkpWallet.init();
+
+				// Broadcast the transaction using PKP wallet
+				const tx = await pkpWallet.sendTransaction({
+					to: fixedTxn.to,
+					data: fixedTxn.data,
+					value: fixedTxn.value,
+					gasLimit: gasLimitFromClient,
+					gasPrice: gasPriceFromClient,
+					nonce: fixedTxn.nonce,
+					chainId: fixedTxn.chainId
+				});
+
+				console.info("Successfully signed and sent transaction", {
+					signature: signingResult.signature,
+					txHash: tx.hash,
+					pkpEthAddress,
+				});
+
+				return res.status(200).json({
+					signature: signingResult.signature,
+					requestId: tx.hash,
+				});
+			} catch (txError) {
+				throw new Error(`Failed to process transaction: ${txError}`);
+			}
+		}
+
+		console.info("Successfully signed and verified message with PKP", {
+			signature: signingResult.signature,
+			pkpEthAddress,
+			recoveredAddress
+		});
+
+		return res.status(200).json({
+			signature: signingResult.signature,
+		});
+	} catch (err) {
+		console.error("[pkpSignHandler] Unable to sign message", {
+			err,
+		});
+		return res.status(500).json({
+			error: `[pkpSignHandler] Unable to sign message: ${JSON.stringify(err)}`,
+			signature: ""
+		});
+	}
+}

--- a/tests/routes/auth/pkpsign.test.ts
+++ b/tests/routes/auth/pkpsign.test.ts
@@ -1,0 +1,275 @@
+import request from "supertest";
+import express from "express";
+import { ethers } from "ethers";
+import { pkpSignHandler } from "../../../routes/auth/pkpSign";
+import { getSigner } from "../../../lit";
+import cors from "cors";
+import { LitNodeClientNodeJs } from "@lit-protocol/lit-node-client-nodejs";
+import { LitRelay, EthWalletProvider } from "@lit-protocol/lit-auth-client";
+import { LIT_NETWORKS_KEYS } from "@lit-protocol/types";
+
+describe("pkpsign Integration Tests", () => {
+  let app: express.Application;
+  let litNodeClient: LitNodeClientNodeJs;
+  let provider: ethers.providers.JsonRpcProvider;
+  let pkp: any;
+  let authMethod: any;
+  let pkpTokenId: ethers.BigNumber;
+
+
+  // Example ABI for PKP contract interactions
+  const PKP_PERMISSIONS_ABI = [
+    'function addDelegatees(uint256 pkpTokenId, address[] calldata delegatees) external',
+    'function getDelegatees(uint256 pkpTokenId) external view returns (address[] memory)'
+  ];
+
+  beforeAll(async () => {
+    // connect to lit so we can sign messages
+    litNodeClient = new LitNodeClientNodeJs({
+      litNetwork: process.env.NETWORK as LIT_NETWORKS_KEYS,
+      debug: false,
+    });
+    await litNodeClient.connect();
+
+    // Set up provider
+    provider = new ethers.providers.JsonRpcProvider(process.env.LIT_TXSENDER_RPC_URL);
+
+    // Get the signer from .env
+    const authWallet = getSigner();
+
+    const litRelay = new LitRelay({
+      relayUrl: LitRelay.getRelayUrl(process.env.NETWORK as LIT_NETWORKS_KEYS),
+      relayApiKey: "test-api-key",
+    });
+
+    authMethod = await EthWalletProvider.authenticate({
+      signer: authWallet,
+      litNodeClient: litNodeClient as any,
+    });
+
+    // Mint a new PKP
+    pkp = await litRelay.mintPKPWithAuthMethods([authMethod], {
+      addPkpEthAddressAsPermittedAddress: true,
+      sendPkpToitself: true
+    });
+
+    // Log PKP details for debugging
+    console.log("Minted PKP:", {
+      pkpPublicKey: pkp.pkpPublicKey,
+      pkpEthAddress: pkp.pkpEthAddress,
+      tokenId: pkp.tokenId,
+      fullResponse: pkp // Log the full response to see what we get
+    });
+
+    // Get token ID from the minting response
+    const tokenId = pkp.pkpTokenId || pkp.tokenId;
+    if (!tokenId) {
+      throw new Error("Failed to get PKP token ID after minting. Full response: " + JSON.stringify(pkp));
+    }
+
+    // Convert hex token ID to decimal BigNumber
+    const tokenIdHex = tokenId.startsWith('0x') ? tokenId : `0x${tokenId}`;
+    pkpTokenId = ethers.BigNumber.from(tokenIdHex);
+
+    console.log("Token ID conversion:", {
+      original: tokenId,
+      hex: tokenIdHex,
+      decimal: pkpTokenId.toString()
+    });
+
+    // Create contract instance to verify permissions
+    const pkpPermissionsContract = new ethers.Contract(
+      "0x2707eabb60D262024F8738455811a338B0ECd3EC",
+      PKP_PERMISSIONS_ABI,
+      provider
+    );
+  }, 60000); // Increase timeout to 60 seconds
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use(cors());
+    app.post("/pkp-sign", pkpSignHandler);
+  });
+
+  afterAll(async () => {
+    litNodeClient.disconnect();
+  });
+
+  it("should successfully sign a message using PKP", async () => {
+    const messageToSign = "Hello, World!";
+
+    const response = await request(app)
+      .post("/pkp-sign")
+      .send({
+        toSign: messageToSign,
+        pkpPublicKey: pkp.pkpPublicKey,
+        authMethod: authMethod,
+      })
+      .expect("Content-Type", /json/)
+      .expect(200);
+
+    expect(response.body).toHaveProperty("signature");
+    expect(response.body.signature).toBeTruthy();
+    expect(pkp.pkpEthAddress).toBeTruthy();
+
+    // Verify the signature was made by the PKP
+    const recoveredAddress = ethers.utils.verifyMessage(
+      messageToSign,
+      response.body.signature
+    );
+    expect(recoveredAddress.toLowerCase()).toBe(pkp.pkpEthAddress!.toLowerCase());
+  });
+
+  it("should successfully sign a contract interaction using PKP", async () => {
+    // Create a contract interface for testing
+    const iface = new ethers.utils.Interface(PKP_PERMISSIONS_ABI);
+    const contractAddress = "0x2707eabb60D262024F8738455811a338B0ECd3EC";
+    
+    // Generate a random Ethereum address as delegatee
+    const delegatee = ethers.Wallet.createRandom().address;
+    
+    // Create addDelegatees transaction data
+    const data = iface.encodeFunctionData("addDelegatees", [
+      pkpTokenId,
+      [delegatee] // Array with single random delegatee address
+    ]);
+
+    console.log("Contract interaction details:", {
+      tokenId: {
+        hex: pkpTokenId.toHexString(),
+        decimal: pkpTokenId.toString()
+      },
+      pkpAddress: pkp.pkpEthAddress,
+      delegatee,
+      contractAddress,
+      encodedData: data,
+    });
+    
+    const transaction = {
+      to: contractAddress,
+      data: data,
+      value: "0x0",
+      gasPrice: await provider.getGasPrice(),
+      nonce: await provider.getTransactionCount(pkp.pkpEthAddress),
+      gasLimit: ethers.BigNumber.from(179970), // Updated to match estimated gas
+      chainId: (await provider.getNetwork()).chainId,
+    };
+
+    // Try to validate the transaction will succeed
+    try {
+      const contract = new ethers.Contract(contractAddress, PKP_PERMISSIONS_ABI, provider);
+      await contract.callStatic.addDelegatees(pkpTokenId, [delegatee], {
+        from: pkp.pkpEthAddress
+      });
+    } catch (error: any) {
+      console.log("Contract call validation failed:", {
+        error: error.message,
+        reason: error.reason,
+        code: error.code,
+        data: error.data,
+        pkpAddress: pkp.pkpEthAddress,
+        tokenId: pkpTokenId.toString(),
+        delegatee
+      });
+    }
+
+    // Log full transaction details
+    console.log("Full transaction details:", {
+      ...transaction,
+      pkpPublicKey: pkp.pkpPublicKey,
+      pkpEthAddress: pkp.pkpEthAddress,
+      tokenId: pkpTokenId.toString()
+    });
+
+    try {
+      const response = await request(app)
+        .post("/pkp-sign")
+        .send({
+          toSign: JSON.stringify(transaction),
+          pkpPublicKey: pkp.pkpPublicKey,
+          authMethod: authMethod,
+          sendTransaction: true
+        });
+
+      console.log("Response from pkp-sign:", {
+        status: response.status,
+        body: response.body,
+        txHash: response.body.requestId // This is the transaction hash
+      });
+
+      // Log transaction hash separately for easy copying
+      if (response.body.requestId) {
+        console.log("Transaction hash:", response.body.requestId);
+      }
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("requestId");
+      expect(response.body.requestId).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+      // Wait for transaction to be mined
+      const txHash = response.body.requestId;
+      await provider.waitForTransaction(txHash);
+
+      // Verify the delegatee was added
+      const contract = new ethers.Contract(contractAddress, PKP_PERMISSIONS_ABI, provider);
+      const delegatees = await contract.getDelegatees(pkpTokenId);
+      console.log("Delegatees after transaction:", {
+        delegatees: delegatees.map((d: string) => d.toLowerCase()),
+        expectedDelegatee: delegatee.toLowerCase()
+      });
+
+      // Check if our delegatee is in the list
+      expect(delegatees.map((d: string) => d.toLowerCase()))
+        .toContain(delegatee.toLowerCase());
+
+    } catch (error: any) {
+      console.log("Error from pkp-sign request:", {
+        error: error.message,
+        response: error.response?.body,
+        errorDetails: error.response?.body?.error
+      });
+      throw error;
+    }
+  }, 60000);
+
+  it("should reject direct ETH transfers", async () => {
+    // Create a simple ETH transfer transaction
+    const transaction = {
+      to: ethers.Wallet.createRandom().address,
+      value: ethers.utils.parseEther("0.1"),
+      gasPrice: await provider.getGasPrice(),
+      nonce: await provider.getTransactionCount(pkp.pkpEthAddress),
+      gasLimit: ethers.BigNumber.from(21000),
+      chainId: (await provider.getNetwork()).chainId,
+      data: "0x" // Empty data field indicates ETH transfer
+    };
+
+    const response = await request(app)
+      .post("/pkp-sign")
+      .send({
+        toSign: JSON.stringify(transaction),
+        pkpPublicKey: pkp.pkpPublicKey,
+        authMethod: authMethod,
+        sendTransaction: true
+      })
+      .expect("Content-Type", /json/)
+      .expect(400);
+
+    expect(response.body.error).toContain("Direct ETH transfers are not allowed");
+  });
+
+  it("should fail with missing parameters", async () => {
+    const response = await request(app)
+      .post("/pkp-sign")
+      .send({
+        toSign: "Hello, World!",
+        // Missing pkpPublicKey and authMethod
+      })
+      .expect("Content-Type", /json/)
+      .expect(400);
+
+    expect(response.body).toHaveProperty("error");
+    expect(response.body.error).toContain("Missing required parameters");
+  });
+}); 

--- a/tests/routes/auth/sendTxn.test.ts
+++ b/tests/routes/auth/sendTxn.test.ts
@@ -12,13 +12,13 @@ import cors from "cors";
 import { Sequencer } from "../../../lib/sequencer";
 import { getTokenIdFromTransferEvent } from "../../../utils/receipt";
 import { LitNodeClientNodeJs } from "@lit-protocol/lit-node-client-nodejs";
-import { LitNetwork } from "@lit-protocol/constants";
+import { LIT_ABILITY } from "@lit-protocol/constants";
+import { LIT_NETWORKS_KEYS } from "@lit-protocol/types";
 import {
 	createSiweMessage,
 	generateAuthSig,
 	LitActionResource,
 	LitPKPResource,
-	LitAbility,
 } from "@lit-protocol/auth-helpers";
 import {
 	estimateGasWithBalanceOverride,
@@ -34,7 +34,7 @@ describe("sendTxn Integration Tests", () => {
 		provider = getProvider();
 		// connect to lit so we can sign the txn
 		litNodeClient = new LitNodeClientNodeJs({
-			litNetwork: process.env.NETWORK as LitNetwork,
+			litNetwork: process.env.NETWORK as LIT_NETWORKS_KEYS,
 			debug: false,
 		});
 		await litNodeClient.connect();
@@ -163,7 +163,7 @@ describe("sendTxn Integration Tests", () => {
 			resources: [
 				{
 					resource: new LitPKPResource(tokenIdFromEvent),
-					ability: LitAbility.PKPSigning,
+					ability: LIT_ABILITY.PKPSigning,
 				},
 			],
 			walletAddress: authWallet.address,
@@ -190,7 +190,7 @@ describe("sendTxn Integration Tests", () => {
 			resourceAbilityRequests: [
 				{
 					resource: new LitPKPResource(tokenIdFromEvent.substring(2)),
-					ability: LitAbility.PKPSigning,
+					ability: LIT_ABILITY.PKPSigning,
 				},
 			],
 			expiration: new Date(Date.now() + 1000 * 60 * 10).toISOString(), // 10 mins

--- a/yarn.lock
+++ b/yarn.lock
@@ -274,56 +274,26 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cosmjs/amino@0.30.1":
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/@cosmjs/amino/-/amino-0.30.1.tgz#7c18c14627361ba6c88e3495700ceea1f76baace"
-  integrity sha512-yNHnzmvAlkETDYIpeCTdVqgvrdt1qgkOXwuRVi8s27UKI5hfqyE9fJ/fuunXE6ZZPnKkjIecDznmuUOMrMvw4w==
-  dependencies:
-    "@cosmjs/crypto" "^0.30.1"
-    "@cosmjs/encoding" "^0.30.1"
-    "@cosmjs/math" "^0.30.1"
-    "@cosmjs/utils" "^0.30.1"
-
-"@cosmjs/crypto@0.30.1", "@cosmjs/crypto@^0.30.1":
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/@cosmjs/crypto/-/crypto-0.30.1.tgz#21e94d5ca8f8ded16eee1389d2639cb5c43c3eb5"
-  integrity sha512-rAljUlake3MSXs9xAm87mu34GfBLN0h/1uPPV6jEwClWjNkAMotzjC0ab9MARy5FFAvYHL3lWb57bhkbt2GtzQ==
-  dependencies:
-    "@cosmjs/encoding" "^0.30.1"
-    "@cosmjs/math" "^0.30.1"
-    "@cosmjs/utils" "^0.30.1"
-    "@noble/hashes" "^1"
-    bn.js "^5.2.0"
-    elliptic "^6.5.4"
-    libsodium-wrappers "^0.7.6"
-
-"@cosmjs/encoding@0.30.1", "@cosmjs/encoding@^0.30.1":
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/@cosmjs/encoding/-/encoding-0.30.1.tgz#b5c4e0ef7ceb1f2753688eb96400ed70f35c6058"
-  integrity sha512-rXmrTbgqwihORwJ3xYhIgQFfMSrwLu1s43RIK9I8EBudPx3KmnmyAKzMOVsRDo9edLFNuZ9GIvysUCwQfq3WlQ==
-  dependencies:
-    base64-js "^1.3.0"
-    bech32 "^1.1.4"
-    readonly-date "^1.0.0"
-
-"@cosmjs/math@^0.30.1":
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/@cosmjs/math/-/math-0.30.1.tgz#8b816ef4de5d3afa66cb9fdfb5df2357a7845b8a"
-  integrity sha512-yaoeI23pin9ZiPHIisa6qqLngfnBR/25tSaWpkTm8Cy10MX70UF5oN4+/t1heLaM6SSmRrhk3psRkV4+7mH51Q==
-  dependencies:
-    bn.js "^5.2.0"
-
-"@cosmjs/utils@^0.30.1":
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.30.1.tgz#6d92582341be3c2ec8d82090253cfa4b7f959edb"
-  integrity sha512-KvvX58MGMWh7xA+N+deCfunkA/ZNDvFLw4YbOmX3f/XBIkqrVY7qlotfy2aNb1kgp6h4B6Yc8YawJPDTfvWX7g==
-
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
+
+"@ethereumjs/rlp@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/rlp/-/rlp-4.0.1.tgz#626fabfd9081baab3d0a3074b0c7ecaf674aaa41"
+  integrity sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==
+
+"@ethereumjs/util@^8.0.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/util/-/util-8.1.0.tgz#299df97fb6b034e0577ce9f94c7d9d1004409ed4"
+  integrity sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==
+  dependencies:
+    "@ethereumjs/rlp" "^4.0.1"
+    ethereum-cryptography "^2.0.0"
+    micro-ftch "^0.3.1"
 
 "@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.7.0":
   version "5.7.0"
@@ -915,113 +885,127 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lit-protocol/access-control-conditions@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/access-control-conditions/-/access-control-conditions-6.2.4.tgz#ecfa752c06c30bd38aeee7d0abc601e007a7dfe8"
-  integrity sha512-nobWVpuR7qdO1eBB1/nV+yxemx4ID+GtRpQoZXjIARw2XmraXNk3oPy/78ciuO2sO9slFusO5CdPx+OHsXyeZw==
+"@lit-protocol/access-control-conditions@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/access-control-conditions/-/access-control-conditions-7.0.6.tgz#6a7d2c361bc966b624f334f283d878c8f4bde86f"
+  integrity sha512-/8TUvt8l0ZrUBJZ7oBT0BC6jhUEUDXh6dQd5IOrlq0v+3b5+a2sUjqR/RD4kT95sEYk2u4qY5amu1OCIFJxkZA==
   dependencies:
     "@ethersproject/abstract-provider" "5.7.0"
     "@ethersproject/contracts" "5.7.0"
     "@ethersproject/providers" "5.7.2"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/constants" "6.2.4"
-    "@lit-protocol/contracts" "^0.0.39"
-    "@lit-protocol/logger" "6.2.4"
-    "@lit-protocol/misc" "6.2.4"
-    "@lit-protocol/types" "6.2.4"
-    "@lit-protocol/uint8arrays" "6.2.4"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/misc" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@lit-protocol/uint8arrays" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
     ajv "^8.12.0"
+    bech32 "^2.0.0"
+    depd "^2.0.0"
     ethers "^5.7.1"
-    jszip "^3.10.1"
-    punycode "2.3.1"
-    siwe "^2.0.5"
+    siwe "^2.3.2"
     tslib "1.14.1"
-    uint8arrays "^4.0.3"
     util "0.12.5"
 
-"@lit-protocol/accs-schemas@0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/accs-schemas/-/accs-schemas-0.0.7.tgz#aad45c27f8c1dc0363a08771bdab50b595dc34d7"
-  integrity sha512-n8fJ6NMh2T3KgSKe0CRB0Uam6ZwxUTQV0oQXY0vEmSL+Q2a1PsM2FX42szOM+O7LgY+Bko7AiCjjDHbqQoJydg==
+"@lit-protocol/accs-schemas@^0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/accs-schemas/-/accs-schemas-0.0.22.tgz#8dd2e6e96836aa22a52c25aac0a686c9ced9f65f"
+  integrity sha512-c3LPDE8g8COt8FdXx+Nfv4CvEvP+QcHh94HZcukcttjZyu6jjICecq/XMXWVUSMGhAVWRMH8tBbjpHzElB45QQ==
   dependencies:
     ajv "^8.12.0"
 
-"@lit-protocol/auth-helpers@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-6.2.4.tgz#6d48c6d419622fa8198533c35f2f1c48ba0335a9"
-  integrity sha512-wy17BS5+LspZq/ehTe5OV06ahHNJv7Qd3y6bGOui1sAyzrCCTIUodcHNr+rqqIkv6LzEb/mkxmemHlX7oOWg0g==
+"@lit-protocol/auth-browser@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-browser/-/auth-browser-7.0.6.tgz#85f50f5ac066272285cc47a0da27797aada3cb32"
+  integrity sha512-ut5OpMwSNTqFj5/Nb4iLEoG3w6PGjCBoH4yu0+y2HP/h8mNj9qtcT6qZtpA8MVoKlDrUcAWRF4oVqL6d14u07w==
+  dependencies:
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/bytes" "5.7.0"
+    "@ethersproject/contracts" "5.7.0"
+    "@ethersproject/providers" "5.7.2"
+    "@ethersproject/strings" "5.7.0"
+    "@ethersproject/wallet" "5.7.0"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/misc" "7.0.6"
+    "@lit-protocol/misc-browser" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@lit-protocol/uint8arrays" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
+    ajv "^8.12.0"
+    bech32 "^2.0.0"
+    depd "^2.0.0"
+    ethers "^5.7.1"
+    tslib "1.14.1"
+
+"@lit-protocol/auth-helpers@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-7.0.6.tgz#9b3258fcd09c6a6718eb72ded6b208992dfd0720"
+  integrity sha512-DRyO9bMeFewnsw2WIqNK5sGboiO4a7zakpN2hhuIIQzu5ukb8QbX0DloSnhm5pCKrw3lw/PG523GHVd92xnpgA==
   dependencies:
     "@ethersproject/abstract-provider" "5.7.0"
     "@ethersproject/contracts" "5.7.0"
     "@ethersproject/providers" "5.7.2"
-    "@lit-protocol/access-control-conditions" "6.2.4"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/constants" "6.2.4"
-    "@lit-protocol/contracts" "^0.0.39"
-    "@lit-protocol/logger" "6.2.4"
-    "@lit-protocol/misc" "6.2.4"
-    "@lit-protocol/types" "6.2.4"
-    "@lit-protocol/uint8arrays" "6.2.4"
+    "@lit-protocol/access-control-conditions" "7.0.6"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/misc" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@lit-protocol/uint8arrays" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
     ajv "^8.12.0"
+    bech32 "^2.0.0"
+    depd "^2.0.0"
     ethers "^5.7.1"
-    jszip "^3.10.1"
-    punycode "2.3.1"
-    siwe "^2.0.5"
+    siwe "^2.3.2"
     siwe-recap "0.0.2-alpha.0"
-    tslib "2.6.0"
-    uint8arrays "^4.0.3"
-    util "0.12.5"
-
-"@lit-protocol/bls-sdk@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/bls-sdk/-/bls-sdk-6.2.4.tgz#cce120a7d28d8372ac0476302b15a159c2b9e79f"
-  integrity sha512-NzS4iAShA8B/0gdOHW9xstZ1JpP9SejppL7Ec9wi4IdKMXwLlW/wRJ7zes6iCjpD75rz9SOLDtoMrBswi0Ju0Q==
-  dependencies:
     tslib "1.14.1"
     util "0.12.5"
 
-"@lit-protocol/constants@6.2.4", "@lit-protocol/constants@^6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-6.2.4.tgz#0f67d9dfd659d43c465c8d60963fe0a4734c891b"
-  integrity sha512-XeW0s7O7a9DerQ4QQ27v/22El5w75f2hNYBRFYM+Ep20d9f4ZaCAZt9j5wkzkbfWYpE6xu2PTECDmDFtqU154A==
+"@lit-protocol/constants@7.0.6", "@lit-protocol/constants@^7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-7.0.6.tgz#2ac000062f207a30b8966dcb07ccc0991750d649"
+  integrity sha512-ZU0V3Ixw/xzHtPnRCK6lf8PdU9P6PyfhQQ8AEeQ7Eygh5dOBA0IFC7hArTa/If/+BssWPdsj5vwIdwKOgIbTMQ==
   dependencies:
     "@ethersproject/abstract-provider" "5.7.0"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/contracts" "^0.0.39"
-    "@lit-protocol/types" "6.2.4"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/types" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
+    depd "^2.0.0"
     ethers "^5.7.1"
-    jszip "^3.10.1"
-    siwe "^2.0.5"
+    siwe "^2.3.2"
     tslib "1.14.1"
 
-"@lit-protocol/contracts-sdk@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/contracts-sdk/-/contracts-sdk-6.2.4.tgz#3d2f5efd9649862b160d92633fd1d64c56bf2540"
-  integrity sha512-BgOhFN6sWUm7nbB97eryFPQ3ESaP7arbA+iXIiRf9Wg2Clu+DQVTAE83PxLgNUewWdbJAaFHRCQrbYrSJTDucQ==
+"@lit-protocol/contracts-sdk@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/contracts-sdk/-/contracts-sdk-7.0.6.tgz#9256a53c28482c523b7fcc1c2147dcfe9fbbc76e"
+  integrity sha512-U87r7JcZFj4i0VhHnVysLrqpWJUEpE7PzqVOLjI6QrqLUGlSAxxDeKL5FHcrK/ZTf7h33pVGQ/DydwIXJPZHeA==
   dependencies:
-    "@cosmjs/amino" "0.30.1"
-    "@cosmjs/crypto" "0.30.1"
-    "@cosmjs/encoding" "0.30.1"
     "@ethersproject/abi" "5.7.0"
     "@ethersproject/abstract-provider" "5.7.0"
     "@ethersproject/contracts" "5.7.0"
     "@ethersproject/providers" "5.7.2"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/constants" "6.2.4"
-    "@lit-protocol/contracts" "^0.0.39"
-    "@lit-protocol/logger" "6.2.4"
-    "@lit-protocol/misc" "6.2.4"
-    "@lit-protocol/types" "6.2.4"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/misc" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
     ajv "^8.12.0"
-    bitcoinjs-lib "^6.1.0"
+    bech32 "^2.0.0"
+    depd "^2.0.0"
     ethers "^5.7.1"
     jose "^4.14.4"
-    jszip "^3.10.1"
     process "0.11.10"
-    punycode "2.3.1"
-    siwe "^2.0.5"
+    siwe "^2.3.2"
     tslib "1.14.1"
-    uint8arrays "^4.0.3"
     util "0.12.5"
 
 "@lit-protocol/contracts@^0.0.39":
@@ -1029,261 +1013,436 @@
   resolved "https://registry.yarnpkg.com/@lit-protocol/contracts/-/contracts-0.0.39.tgz#e2483f1ef3df63bd434bcc7c00414b8f2e8d9ec5"
   integrity sha512-zz/TaKWUqFK2n7BqwKj9PeV0px89G7dnjkRJ9BM/eri356zodd/W5d5iGQUVdaFiCYKd/cibm4004BnuMlXLeg==
 
-"@lit-protocol/core@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/core/-/core-6.2.4.tgz#540567302da8e38ef733ce864c122509832007f8"
-  integrity sha512-r8zKTIoU+aNrR0nBf96xeB0RJvWw3K78d65+RQuVXa7wx8gtItC9XUb1MfeBqoZRli5Swih38S2glt5Mt6RuKQ==
+"@lit-protocol/contracts@^0.0.74":
+  version "0.0.74"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/contracts/-/contracts-0.0.74.tgz#e726a9190c86b10cc6df3a392cd04d19057be27d"
+  integrity sha512-8uV038gzBp7ew7a4884SVt9Zhu8CtiTb+A8dKNnByxVoT1kFt4O4DmsaniV8p9AGjNR13IWfpU1NFChmPHVIpQ==
+
+"@lit-protocol/core@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/core/-/core-7.0.6.tgz#e8beae20325310d583acae4e2a2db3a23387ab2a"
+  integrity sha512-c8Q1kMGD1qp1jJZhJl/rHxgi5l0vEpyPrbtRpwMHOZQ65Yi69WPvvC/kj7Zn5sAqYXPcfXX4i9nAXlbOktIIuw==
   dependencies:
-    "@cosmjs/amino" "0.30.1"
-    "@cosmjs/crypto" "0.30.1"
-    "@cosmjs/encoding" "0.30.1"
     "@ethersproject/abi" "5.7.0"
     "@ethersproject/abstract-provider" "5.7.0"
     "@ethersproject/contracts" "5.7.0"
     "@ethersproject/providers" "5.7.2"
-    "@lit-protocol/access-control-conditions" "6.2.4"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/bls-sdk" "6.2.4"
-    "@lit-protocol/constants" "6.2.4"
-    "@lit-protocol/contracts" "^0.0.39"
-    "@lit-protocol/contracts-sdk" "6.2.4"
-    "@lit-protocol/crypto" "6.2.4"
-    "@lit-protocol/ecdsa-sdk" "6.2.4"
-    "@lit-protocol/logger" "6.2.4"
-    "@lit-protocol/misc" "6.2.4"
-    "@lit-protocol/nacl" "6.2.4"
-    "@lit-protocol/sev-snp-utils-sdk" "6.2.4"
-    "@lit-protocol/types" "6.2.4"
-    "@lit-protocol/uint8arrays" "6.2.4"
+    "@lit-protocol/access-control-conditions" "7.0.6"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/contracts-sdk" "7.0.6"
+    "@lit-protocol/crypto" "7.0.6"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/misc" "7.0.6"
+    "@lit-protocol/nacl" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@lit-protocol/uint8arrays" "7.0.6"
+    "@lit-protocol/wasm" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
     ajv "^8.12.0"
-    bitcoinjs-lib "^6.1.0"
-    bs58 "^5.0.0"
-    cross-fetch "3.1.4"
+    bech32 "^2.0.0"
     date-and-time "^2.4.1"
+    depd "^2.0.0"
     ethers "^5.7.1"
     jose "^4.14.4"
-    jszip "^3.10.1"
     multiformats "^9.7.1"
-    pako "1.0.11"
+    pako "^2.1.0"
     process "0.11.10"
-    punycode "2.3.1"
-    siwe "^2.0.5"
+    siwe "^2.3.2"
     tslib "1.14.1"
-    uint8arrays "^4.0.3"
     util "0.12.5"
 
-"@lit-protocol/crypto@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/crypto/-/crypto-6.2.4.tgz#ae2aa819533e963c6a2edf44a606951bd2b48d7d"
-  integrity sha512-NIrteNXlTSg1+QZteL/8lF737ncRMpoWAoU2EHv/QQNNQMeTRByv+IsqbnwX2zm7zvw07zLvxWrXdYgR4luXTg==
+"@lit-protocol/crypto@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/crypto/-/crypto-7.0.6.tgz#3894b63ca149145d5f2f247b3ba5d73b93113d75"
+  integrity sha512-mLOJ4DUnA0+2CxqQHanhFPLeeCoO6JU7PkbJVz3IDvus0vZzR++UY443hJAoiHk3Yy3N920uj7d7H7967TFO3A==
   dependencies:
     "@ethersproject/abstract-provider" "5.7.0"
     "@ethersproject/contracts" "5.7.0"
     "@ethersproject/providers" "5.7.2"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/bls-sdk" "6.2.4"
-    "@lit-protocol/constants" "6.2.4"
-    "@lit-protocol/contracts" "^0.0.39"
-    "@lit-protocol/ecdsa-sdk" "6.2.4"
-    "@lit-protocol/logger" "6.2.4"
-    "@lit-protocol/misc" "6.2.4"
-    "@lit-protocol/nacl" "6.2.4"
-    "@lit-protocol/sev-snp-utils-sdk" "6.2.4"
-    "@lit-protocol/types" "6.2.4"
-    "@lit-protocol/uint8arrays" "6.2.4"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/misc" "7.0.6"
+    "@lit-protocol/nacl" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@lit-protocol/uint8arrays" "7.0.6"
+    "@lit-protocol/wasm" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
     ajv "^8.12.0"
-    cross-fetch "3.1.4"
+    bech32 "^2.0.0"
+    depd "^2.0.0"
     ethers "^5.7.1"
-    jszip "^3.10.1"
-    pako "1.0.11"
-    punycode "2.3.1"
-    siwe "^2.0.5"
-    tslib "1.14.1"
-    uint8arrays "^4.0.3"
-    util "0.12.5"
-
-"@lit-protocol/ecdsa-sdk@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/ecdsa-sdk/-/ecdsa-sdk-6.2.4.tgz#4ab9b2b59b60c425beda27d0ca6febfc228895b1"
-  integrity sha512-NEyA6BVwXbEn3DgzE9PLY3XrzO1Ju51yNozZhYVzPlpbWx0vqGd/zBa7MKc5qIWBpi1JPoO+QBonv3/29CjycQ==
-  dependencies:
+    pako "^2.1.0"
+    siwe "^2.3.2"
     tslib "1.14.1"
     util "0.12.5"
 
-"@lit-protocol/encryption@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/encryption/-/encryption-6.2.4.tgz#a8cce11357ac0c692f9ab7af01083a9fe7536eb4"
-  integrity sha512-6d8T69omItywhDX+2IA+JHgiV4Nnu6E4+769X4ceZzMaRI0LoPXMbQ4HaI6s3EtCJZmwROyxX1LtmvwfzNQ8RQ==
+"@lit-protocol/lit-auth-client@^7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/lit-auth-client/-/lit-auth-client-7.0.6.tgz#d3d05312099f599c228f3615f9b4166dd739c8c3"
+  integrity sha512-VIwxSl5edj7fwRQs/1+fnesPoTl7+yFIrsDzKvXGPUkJlmQ/ilkUvua7Aptrei1IZ6uMzieofYGJXGuU8gzc0w==
   dependencies:
+    "@ethersproject/abi" "5.7.0"
     "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/bytes" "5.7.0"
     "@ethersproject/contracts" "5.7.0"
     "@ethersproject/providers" "5.7.2"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/bls-sdk" "6.2.4"
-    "@lit-protocol/constants" "6.2.4"
-    "@lit-protocol/contracts" "^0.0.39"
-    "@lit-protocol/crypto" "6.2.4"
-    "@lit-protocol/ecdsa-sdk" "6.2.4"
-    "@lit-protocol/logger" "6.2.4"
-    "@lit-protocol/misc" "6.2.4"
-    "@lit-protocol/nacl" "6.2.4"
-    "@lit-protocol/sev-snp-utils-sdk" "6.2.4"
-    "@lit-protocol/types" "6.2.4"
-    "@lit-protocol/uint8arrays" "6.2.4"
+    "@ethersproject/strings" "5.7.0"
+    "@ethersproject/transactions" "5.7.0"
+    "@ethersproject/wallet" "5.7.0"
+    "@lit-protocol/access-control-conditions" "7.0.6"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/auth-browser" "7.0.6"
+    "@lit-protocol/auth-helpers" "7.0.6"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/contracts-sdk" "7.0.6"
+    "@lit-protocol/core" "7.0.6"
+    "@lit-protocol/crypto" "7.0.6"
+    "@lit-protocol/lit-node-client" "7.0.6"
+    "@lit-protocol/lit-node-client-nodejs" "7.0.6"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/misc" "7.0.6"
+    "@lit-protocol/misc-browser" "7.0.6"
+    "@lit-protocol/nacl" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@lit-protocol/uint8arrays" "7.0.6"
+    "@lit-protocol/wasm" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
+    "@walletconnect/ethereum-provider" "2.9.2"
     ajv "^8.12.0"
-    cross-fetch "3.1.4"
+    base64url "^3.0.1"
+    bech32 "^2.0.0"
+    cbor-web "^9.0.2"
+    cross-fetch "3.1.8"
+    date-and-time "^2.4.1"
+    depd "^2.0.0"
     ethers "^5.7.1"
-    jszip "^3.10.1"
-    pako "1.0.11"
-    punycode "2.3.1"
-    siwe "^2.0.5"
-    tslib "1.14.1"
-    uint8arrays "^4.0.3"
+    jose "^4.14.4"
+    multiformats "^9.7.1"
+    pako "^2.1.0"
+    process "0.11.10"
+    siwe "^2.3.2"
+    siwe-recap "0.0.2-alpha.0"
+    tslib "^2.7.0"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
     util "0.12.5"
 
-"@lit-protocol/lit-node-client-nodejs@^6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/lit-node-client-nodejs/-/lit-node-client-nodejs-6.2.4.tgz#6db12dbfbe1add4ef1be0aad46af7bb077e87bfc"
-  integrity sha512-+CbTkuoIJlrhFO36ZjdSyaZ6DqQuNuyitj5PvkQqqxxRFhd1PLDkk2gEbGVQoA78Hk2T1k79F87rMLDoE91+5g==
+"@lit-protocol/lit-node-client-nodejs@7.0.6", "@lit-protocol/lit-node-client-nodejs@^7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/lit-node-client-nodejs/-/lit-node-client-nodejs-7.0.6.tgz#6f52a4bd6a6eebf263f916ef02ee9bd5e70b9d37"
+  integrity sha512-c6SuvNG5QMtp6IZo1KBwKzjQtXPmrwsnfV93IKkO6CmfrR4kjUa9E3F9MbuyJauqhXybvcnvl4MUOCqlM+RWwQ==
   dependencies:
-    "@cosmjs/amino" "0.30.1"
-    "@cosmjs/crypto" "0.30.1"
-    "@cosmjs/encoding" "0.30.1"
     "@ethersproject/abi" "5.7.0"
     "@ethersproject/abstract-provider" "5.7.0"
     "@ethersproject/contracts" "5.7.0"
     "@ethersproject/providers" "5.7.2"
     "@ethersproject/transactions" "5.7.0"
-    "@lit-protocol/access-control-conditions" "6.2.4"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/auth-helpers" "6.2.4"
-    "@lit-protocol/bls-sdk" "6.2.4"
-    "@lit-protocol/constants" "6.2.4"
-    "@lit-protocol/contracts" "^0.0.39"
-    "@lit-protocol/contracts-sdk" "6.2.4"
-    "@lit-protocol/core" "6.2.4"
-    "@lit-protocol/crypto" "6.2.4"
-    "@lit-protocol/ecdsa-sdk" "6.2.4"
-    "@lit-protocol/encryption" "6.2.4"
-    "@lit-protocol/logger" "6.2.4"
-    "@lit-protocol/misc" "6.2.4"
-    "@lit-protocol/misc-browser" "6.2.4"
-    "@lit-protocol/nacl" "6.2.4"
-    "@lit-protocol/sev-snp-utils-sdk" "6.2.4"
-    "@lit-protocol/types" "6.2.4"
-    "@lit-protocol/uint8arrays" "6.2.4"
+    "@lit-protocol/access-control-conditions" "7.0.6"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/auth-helpers" "7.0.6"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/contracts-sdk" "7.0.6"
+    "@lit-protocol/core" "7.0.6"
+    "@lit-protocol/crypto" "7.0.6"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/misc" "7.0.6"
+    "@lit-protocol/misc-browser" "7.0.6"
+    "@lit-protocol/nacl" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@lit-protocol/uint8arrays" "7.0.6"
+    "@lit-protocol/wasm" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
     ajv "^8.12.0"
-    bitcoinjs-lib "^6.1.0"
-    bs58 "^5.0.0"
-    cross-fetch "3.1.4"
+    bech32 "^2.0.0"
+    cross-fetch "3.1.8"
     date-and-time "^2.4.1"
+    depd "^2.0.0"
     ethers "^5.7.1"
     jose "^4.14.4"
-    jszip "^3.10.1"
     multiformats "^9.7.1"
-    pako "1.0.11"
+    pako "^2.1.0"
     process "0.11.10"
-    punycode "2.3.1"
-    siwe "^2.0.5"
+    siwe "^2.3.2"
     siwe-recap "0.0.2-alpha.0"
-    tslib "^2.3.0"
-    uint8arrays "^4.0.3"
+    tslib "1.14.1"
     util "0.12.5"
 
-"@lit-protocol/logger@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/logger/-/logger-6.2.4.tgz#5f34081dc242720836bed9fd5fde10327906a658"
-  integrity sha512-o3yXdkBXcU/h+glwH6LMDzjFQnfmuzijDwPfQa39eMgKSdXVqwEoF9jGNhLS+0K1jYHgxTjenvbJVdz8GcfW+w==
+"@lit-protocol/lit-node-client@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/lit-node-client/-/lit-node-client-7.0.6.tgz#492039ac0b8c6c425fc55dffd1fae391afbb275a"
+  integrity sha512-GslygaQaewY5Y9FALYPAE+/owAduWubzMPzApE8xE0dsbQz314rCCEvV6uO0/Ti5mWG362VtvHcdB6Jk1n+zJA==
+  dependencies:
+    "@ethersproject/abi" "5.7.0"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/bytes" "5.7.0"
+    "@ethersproject/contracts" "5.7.0"
+    "@ethersproject/providers" "5.7.2"
+    "@ethersproject/strings" "5.7.0"
+    "@ethersproject/transactions" "5.7.0"
+    "@ethersproject/wallet" "5.7.0"
+    "@lit-protocol/access-control-conditions" "7.0.6"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/auth-browser" "7.0.6"
+    "@lit-protocol/auth-helpers" "7.0.6"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/contracts-sdk" "7.0.6"
+    "@lit-protocol/core" "7.0.6"
+    "@lit-protocol/crypto" "7.0.6"
+    "@lit-protocol/lit-node-client-nodejs" "7.0.6"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/misc" "7.0.6"
+    "@lit-protocol/misc-browser" "7.0.6"
+    "@lit-protocol/nacl" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@lit-protocol/uint8arrays" "7.0.6"
+    "@lit-protocol/wasm" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
+    "@walletconnect/ethereum-provider" "2.9.2"
+    ajv "^8.12.0"
+    bech32 "^2.0.0"
+    cross-fetch "3.1.8"
+    date-and-time "^2.4.1"
+    depd "^2.0.0"
+    ethers "^5.7.1"
+    jose "^4.14.4"
+    multiformats "^9.7.1"
+    pako "^2.1.0"
+    process "0.11.10"
+    siwe "^2.3.2"
+    siwe-recap "0.0.2-alpha.0"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
+    util "0.12.5"
+
+"@lit-protocol/logger@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/logger/-/logger-7.0.6.tgz#2ed42c5250a72745d1a1779ca067cf30bc188b65"
+  integrity sha512-dj8FAjpB+o46IIFHxH7++wUhUjzlXAJ2GXltj9RWcoAag6sPZftiLnDxZyU2RzqWLI1K2gtYuYn7aAOO94sgXA==
   dependencies:
     "@ethersproject/abstract-provider" "5.7.0"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/constants" "6.2.4"
-    "@lit-protocol/contracts" "^0.0.39"
-    "@lit-protocol/types" "6.2.4"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/types" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
+    depd "^2.0.0"
     ethers "^5.7.1"
-    jszip "^3.10.1"
-    punycode "2.3.1"
-    siwe "^2.0.5"
+    siwe "^2.3.2"
     tslib "1.14.1"
-    uint8arrays "^4.0.3"
 
-"@lit-protocol/misc-browser@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/misc-browser/-/misc-browser-6.2.4.tgz#effd0ba1378c02cea94e165c1dfce3db3e2e2544"
-  integrity sha512-B7tXcdtb6xMmi3AtC2kzpUbVWkyh8//Lo+zYRe4zr1BFxkmf4f/JtXplfIkG01GXVo6q27mVCHgAZhTJTq++rw==
+"@lit-protocol/misc-browser@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/misc-browser/-/misc-browser-7.0.6.tgz#2797d35bc378d6cc8dc76b887fcd2291d2aa5e42"
+  integrity sha512-E7ZhF6aG3Jl7K2ua2x/w8mLupPv345m1FrfvNdet1iIqwddV2q+2rQFgh0fO7lfxRvXuiteGuBvL9ecPPLRecw==
   dependencies:
     "@ethersproject/abstract-provider" "5.7.0"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/constants" "6.2.4"
-    "@lit-protocol/contracts" "^0.0.39"
-    "@lit-protocol/types" "6.2.4"
-    "@lit-protocol/uint8arrays" "6.2.4"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/types" "7.0.6"
+    "@lit-protocol/uint8arrays" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
+    depd "^2.0.0"
     ethers "^5.7.1"
-    jszip "^3.10.1"
-    siwe "^2.0.5"
+    siwe "^2.3.2"
     tslib "1.14.1"
 
-"@lit-protocol/misc@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/misc/-/misc-6.2.4.tgz#c00f96890349acbb839a016e3f2289f77a2495ec"
-  integrity sha512-3slWB+ebTw9p10NbxiPZdulIUHc7fyavYUQqupYk2AIAJJKdjlWmyFQRgZ8gJOtWdN8DBSXuuOKxVOCac08Esw==
+"@lit-protocol/misc@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/misc/-/misc-7.0.6.tgz#8a5c84c5adea92718aa512e681df8c1a0f5f376a"
+  integrity sha512-wJJHS3XJZXCofBxtRiMOdSfcE55eZxoqyVbiE57qKlMoVWLBQdv4LUExaWdrmVZBPKLdShFfBCtz0sAMagrOyg==
   dependencies:
     "@ethersproject/abstract-provider" "5.7.0"
     "@ethersproject/contracts" "5.7.0"
     "@ethersproject/providers" "5.7.2"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/constants" "6.2.4"
-    "@lit-protocol/contracts" "^0.0.39"
-    "@lit-protocol/logger" "6.2.4"
-    "@lit-protocol/types" "6.2.4"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
     ajv "^8.12.0"
+    bech32 "^2.0.0"
+    depd "^2.0.0"
     ethers "^5.7.1"
-    jszip "^3.10.1"
-    punycode "2.3.1"
-    siwe "^2.0.5"
+    siwe "^2.3.2"
     tslib "1.14.1"
-    uint8arrays "^4.0.3"
     util "0.12.5"
 
-"@lit-protocol/nacl@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/nacl/-/nacl-6.2.4.tgz#a1b25a922eb1bdf789ebbef30b339c802e4edf89"
-  integrity sha512-jVsoDPiffrpWqWmiYgV19tXOfVe+SzPJG9shZIGveDU2OsCgtb0Fhpk6LuuH4G0iwzD+K6qS0YKcQuOnMgpY2Q==
+"@lit-protocol/nacl@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/nacl/-/nacl-7.0.6.tgz#937832f4d9cf60209ea1bb3bb3f77b82ca0067ea"
+  integrity sha512-KjO6NzKQIlHNF1utIQvsHFVHtKCGVPjotxIC6DAjU/9ddNKBRKggJyP2AhFIinavldy38hgtikeNuZdUcg5z7A==
   dependencies:
     tslib "1.14.1"
 
-"@lit-protocol/sev-snp-utils-sdk@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/sev-snp-utils-sdk/-/sev-snp-utils-sdk-6.2.4.tgz#f5b48c8e666a28889bd8ed52f74abce651253ef0"
-  integrity sha512-k94cgi7lzfCHl8Qf7SwGCqcT1wgeUwki3FQQE5oQxvm/+SADFJLTWS/IeLO1eT4w99BINGvLdAs66RFq4FnqXg==
+"@lit-protocol/pkp-base@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/pkp-base/-/pkp-base-7.0.6.tgz#6c8989316e9d34ae346378c1f8d145654e54c895"
+  integrity sha512-daKhwShUYME9Ci7E3LpqKhCmlHLbAztLlBdmCTelAOIchIeXnFGNUL4kxPw59ZKd4HN3dBCNq0Mi4pzmakLqRQ==
   dependencies:
-    cross-fetch "3.1.4"
-    tslib "1.14.1"
+    "@ethersproject/abi" "5.7.0"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/bytes" "5.7.0"
+    "@ethersproject/contracts" "5.7.0"
+    "@ethersproject/providers" "5.7.2"
+    "@ethersproject/strings" "5.7.0"
+    "@ethersproject/transactions" "5.7.0"
+    "@ethersproject/wallet" "5.7.0"
+    "@lit-protocol/access-control-conditions" "7.0.6"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/auth-browser" "7.0.6"
+    "@lit-protocol/auth-helpers" "7.0.6"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/contracts-sdk" "7.0.6"
+    "@lit-protocol/core" "7.0.6"
+    "@lit-protocol/crypto" "7.0.6"
+    "@lit-protocol/lit-node-client" "7.0.6"
+    "@lit-protocol/lit-node-client-nodejs" "7.0.6"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/misc" "7.0.6"
+    "@lit-protocol/misc-browser" "7.0.6"
+    "@lit-protocol/nacl" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@lit-protocol/uint8arrays" "7.0.6"
+    "@lit-protocol/wasm" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
+    "@walletconnect/ethereum-provider" "2.9.2"
+    ajv "^8.12.0"
+    bech32 "^2.0.0"
+    cross-fetch "3.1.8"
+    date-and-time "^2.4.1"
+    depd "^2.0.0"
+    ethers "^5.7.1"
+    jose "^4.14.4"
+    multiformats "^9.7.1"
+    pako "^2.1.0"
+    process "0.11.10"
+    siwe "^2.3.2"
+    siwe-recap "0.0.2-alpha.0"
+    tslib "^2.7.0"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
+    util "0.12.5"
 
-"@lit-protocol/types@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-6.2.4.tgz#26b74baf78755cf8ae33f1d5bc9344d459cf5a4f"
-  integrity sha512-aenWLkPEEvyJg6VRu+/IbDL4JilRk5aoQ+ayL/UORSZtTnpfRf23LBef9pchMWXnUYXIr4X/vrko0Ru+tostTQ==
+"@lit-protocol/pkp-ethers@^7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/pkp-ethers/-/pkp-ethers-7.0.6.tgz#1b7eb8985503070fd21a5386256609f979ab8233"
+  integrity sha512-GLmcThbHDBnWdlYxZSIvMWUfIeCgL1MD8m0/CPlS5gQxDqydyARUY3gm5HCFUt9iMvESzi0CuciW+TGtwDDm5A==
+  dependencies:
+    "@ethersproject/abi" "5.7.0"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/abstract-signer" "5.7.0"
+    "@ethersproject/address" "5.7.0"
+    "@ethersproject/bytes" "5.7.0"
+    "@ethersproject/contracts" "5.7.0"
+    "@ethersproject/hash" "5.7.0"
+    "@ethersproject/hdnode" "5.7.0"
+    "@ethersproject/json-wallets" "5.7.0"
+    "@ethersproject/keccak256" "5.7.0"
+    "@ethersproject/logger" "5.7.0"
+    "@ethersproject/properties" "5.7.0"
+    "@ethersproject/providers" "5.7.2"
+    "@ethersproject/random" "5.7.0"
+    "@ethersproject/strings" "5.7.0"
+    "@ethersproject/transactions" "5.7.0"
+    "@ethersproject/wallet" "5.7.0"
+    "@ethersproject/wordlists" "5.7.0"
+    "@lit-protocol/access-control-conditions" "7.0.6"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/auth-browser" "7.0.6"
+    "@lit-protocol/auth-helpers" "7.0.6"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/contracts-sdk" "7.0.6"
+    "@lit-protocol/core" "7.0.6"
+    "@lit-protocol/crypto" "7.0.6"
+    "@lit-protocol/lit-node-client" "7.0.6"
+    "@lit-protocol/lit-node-client-nodejs" "7.0.6"
+    "@lit-protocol/logger" "7.0.6"
+    "@lit-protocol/misc" "7.0.6"
+    "@lit-protocol/misc-browser" "7.0.6"
+    "@lit-protocol/nacl" "7.0.6"
+    "@lit-protocol/pkp-base" "7.0.6"
+    "@lit-protocol/types" "7.0.6"
+    "@lit-protocol/uint8arrays" "7.0.6"
+    "@lit-protocol/wasm" "7.0.6"
+    "@metamask/eth-sig-util" "5.0.2"
+    "@openagenda/verror" "^3.1.4"
+    "@walletconnect/ethereum-provider" "2.9.2"
+    ajv "^8.12.0"
+    bech32 "^2.0.0"
+    cross-fetch "3.1.8"
+    date-and-time "^2.4.1"
+    depd "^2.0.0"
+    ethers "^5.7.1"
+    jose "^4.14.4"
+    multiformats "^9.7.1"
+    pako "^2.1.0"
+    process "0.11.10"
+    siwe "^2.3.2"
+    siwe-recap "0.0.2-alpha.0"
+    tslib "^2.7.0"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
+    util "0.12.5"
+
+"@lit-protocol/types@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-7.0.6.tgz#22d84f3a6b514b7eba056e3ae88e987fb025388e"
+  integrity sha512-PT0m2hQuPhaXoDURsJkeUF8Nq8s4JGeamGmxLMLSLCoctXrFWBiCjw5GDOYLoFe3cEHPQSj19rm9mzyjxkqQ8g==
   dependencies:
     "@ethersproject/abstract-provider" "5.7.0"
-    "@lit-protocol/accs-schemas" "0.0.7"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    depd "^2.0.0"
     ethers "^5.7.1"
-    jszip "^3.10.1"
-    siwe "^2.0.5"
+    siwe "^2.3.2"
     tslib "1.14.1"
 
-"@lit-protocol/uint8arrays@6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/uint8arrays/-/uint8arrays-6.2.4.tgz#6d02a131d9c2fd8041d2260758074dbdc175c27b"
-  integrity sha512-pGVO8DL+dwOs491q05nF5beHh5dBygOgO20nCNcyyb4RICRllWcT7y+duvkmw6N2dcM6tGGZUwMLmGyQD5U06Q==
+"@lit-protocol/uint8arrays@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/uint8arrays/-/uint8arrays-7.0.6.tgz#1f4d03a3ccb25c8ceac42ceff1cff588e9ea8533"
+  integrity sha512-oglAr1abSsDLPKehFx4MKK3dXxvt+G45sPyb+kAjryq+MxoNhHMs5IyBgmrWiSjcB3dyuBxnwErKygbyRtj1aQ==
   dependencies:
     "@ethersproject/abstract-provider" "5.7.0"
-    "@lit-protocol/accs-schemas" "0.0.7"
-    "@lit-protocol/contracts" "^0.0.39"
+    "@lit-protocol/accs-schemas" "^0.0.22"
+    "@lit-protocol/constants" "7.0.6"
+    "@lit-protocol/contracts" "^0.0.74"
+    "@lit-protocol/types" "7.0.6"
+    "@openagenda/verror" "^3.1.4"
+    depd "^2.0.0"
     ethers "^5.7.1"
-    jszip "^3.10.1"
-    siwe "^2.0.5"
+    siwe "^2.3.2"
     tslib "1.14.1"
+
+"@lit-protocol/wasm@7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/wasm/-/wasm-7.0.6.tgz#cb7053fb5f8a9ef0ea3e5634ced88c87c0b7f411"
+  integrity sha512-iZezuneICRvk+0+eh7me51vRH5i1qNmYxztEPfRkzxgWRnoRfqeLcSbMNGdo+Y+HCOJTon1+y1d7qrnZnE9r5g==
+  dependencies:
+    ethers "^5.7.1"
+    pako "^2.1.0"
+    tslib "1.14.1"
+
+"@metamask/eth-sig-util@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-5.0.2.tgz#c518279a6e17a88135a13d53a0b970f145ff8bce"
+  integrity sha512-RU6fG/H6/UlBol221uBkq5C7w3TwLK611nEZliO2u+kO0vHKGBXnIPlhI0tzKUigjhUeOd9mhCNbNvhh0LKt9Q==
+  dependencies:
+    "@ethereumjs/util" "^8.0.0"
+    bn.js "^4.11.8"
+    ethereum-cryptography "^1.1.2"
+    ethjs-util "^0.1.6"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
 
 "@noble/curves@1.4.2", "@noble/curves@~1.4.0":
   version "1.4.2"
@@ -1292,15 +1451,47 @@
   dependencies:
     "@noble/hashes" "1.4.0"
 
+"@noble/curves@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.8.0.tgz#fe035a23959e6aeadf695851b51a87465b5ba8f7"
+  integrity sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==
+  dependencies:
+    "@noble/hashes" "1.7.0"
+
 "@noble/ed25519@^1.6.1":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.3.tgz#57e1677bf6885354b466c38e2b620c62f45a7123"
   integrity sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==
 
-"@noble/hashes@1.4.0", "@noble/hashes@^1", "@noble/hashes@^1.1.2", "@noble/hashes@^1.2.0", "@noble/hashes@~1.4.0":
+"@noble/hashes@1.2.0", "@noble/hashes@~1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.2.0.tgz#a3150eeb09cc7ab207ebf6d7b9ad311a9bdbed12"
+  integrity sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==
+
+"@noble/hashes@1.4.0", "@noble/hashes@^1.1.2", "@noble/hashes@~1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
   integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
+"@noble/hashes@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.0.tgz#5d9e33af2c7d04fee35de1519b80c958b2e35e39"
+  integrity sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==
+
+"@noble/secp256k1@1.7.1", "@noble/secp256k1@~1.7.0":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
+  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
+
+"@openagenda/verror@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@openagenda/verror/-/verror-3.1.4.tgz#a3560168e91dc35ae8c0823af70556a5a0bb8d60"
+  integrity sha512-+V7QuD6v5sMWez7cu+5DXoXMim+iQssOcspoNgbWDW8sEyC54Mdo5VuIkcIjqhPmQYOzBWo5qlbzNGEpD6PzMA==
+  dependencies:
+    assertion-error "^1.1.0"
+    depd "^2.0.0"
+    inherits "^2.0.4"
+    sprintf-js "^1.1.2"
 
 "@peculiar/asn1-android@^2.1.7":
   version "2.3.10"
@@ -1365,10 +1556,24 @@
   resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.0.5.tgz#a6d70ef7a0e71e083ea09b967df0a0ed742bc6ad"
   integrity sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==
 
+"@scure/base@~1.1.0":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
+
 "@scure/base@~1.1.6":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.7.tgz#fe973311a5c6267846aa131bc72e96c5d40d2b30"
   integrity sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==
+
+"@scure/bip32@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.1.5.tgz#d2ccae16dcc2e75bc1d75f5ef3c66a338d1ba300"
+  integrity sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==
+  dependencies:
+    "@noble/hashes" "~1.2.0"
+    "@noble/secp256k1" "~1.7.0"
+    "@scure/base" "~1.1.0"
 
 "@scure/bip32@1.4.0":
   version "1.4.0"
@@ -1378,6 +1583,14 @@
     "@noble/curves" "~1.4.0"
     "@noble/hashes" "~1.4.0"
     "@scure/base" "~1.1.6"
+
+"@scure/bip39@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.1.1.tgz#b54557b2e86214319405db819c4b6a370cf340c5"
+  integrity sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==
+  dependencies:
+    "@noble/hashes" "~1.2.0"
+    "@scure/base" "~1.1.0"
 
 "@scure/bip39@1.3.0":
   version "1.3.0"
@@ -1438,6 +1651,11 @@
     uri-js "^4.4.1"
     valid-url "^1.0.9"
 
+"@stablelib/aead@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/aead/-/aead-1.0.1.tgz#c4b1106df9c23d1b867eb9b276d8f42d5fc4c0c3"
+  integrity sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==
+
 "@stablelib/binary@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stablelib/binary/-/binary-1.0.1.tgz#c5900b94368baf00f811da5bdb1610963dfddf7f"
@@ -1445,12 +1663,80 @@
   dependencies:
     "@stablelib/int" "^1.0.1"
 
+"@stablelib/bytes@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/bytes/-/bytes-1.0.1.tgz#0f4aa7b03df3080b878c7dea927d01f42d6a20d8"
+  integrity sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ==
+
+"@stablelib/chacha20poly1305@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz#de6b18e283a9cb9b7530d8767f99cde1fec4c2ee"
+  integrity sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==
+  dependencies:
+    "@stablelib/aead" "^1.0.1"
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/chacha" "^1.0.1"
+    "@stablelib/constant-time" "^1.0.1"
+    "@stablelib/poly1305" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/chacha@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/chacha/-/chacha-1.0.1.tgz#deccfac95083e30600c3f92803a3a1a4fa761371"
+  integrity sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==
+  dependencies:
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/constant-time@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/constant-time/-/constant-time-1.0.1.tgz#bde361465e1cf7b9753061b77e376b0ca4c77e35"
+  integrity sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==
+
+"@stablelib/hash@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/hash/-/hash-1.0.1.tgz#3c944403ff2239fad8ebb9015e33e98444058bc5"
+  integrity sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==
+
+"@stablelib/hkdf@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/hkdf/-/hkdf-1.0.1.tgz#b4efd47fd56fb43c6a13e8775a54b354f028d98d"
+  integrity sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==
+  dependencies:
+    "@stablelib/hash" "^1.0.1"
+    "@stablelib/hmac" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/hmac@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/hmac/-/hmac-1.0.1.tgz#3d4c1b8cf194cb05d28155f0eed8a299620a07ec"
+  integrity sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==
+  dependencies:
+    "@stablelib/constant-time" "^1.0.1"
+    "@stablelib/hash" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
 "@stablelib/int@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stablelib/int/-/int-1.0.1.tgz#75928cc25d59d73d75ae361f02128588c15fd008"
   integrity sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==
 
-"@stablelib/random@^1.0.1":
+"@stablelib/keyagreement@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz#4612efb0a30989deb437cd352cee637ca41fc50f"
+  integrity sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==
+  dependencies:
+    "@stablelib/bytes" "^1.0.1"
+
+"@stablelib/poly1305@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/poly1305/-/poly1305-1.0.1.tgz#93bfb836c9384685d33d70080718deae4ddef1dc"
+  integrity sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==
+  dependencies:
+    "@stablelib/constant-time" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
+"@stablelib/random@^1.0.1", "@stablelib/random@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@stablelib/random/-/random-1.0.2.tgz#2dece393636489bf7e19c51229dd7900eddf742c"
   integrity sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==
@@ -1458,10 +1744,28 @@
     "@stablelib/binary" "^1.0.1"
     "@stablelib/wipe" "^1.0.1"
 
+"@stablelib/sha256@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/sha256/-/sha256-1.0.1.tgz#77b6675b67f9b0ea081d2e31bda4866297a3ae4f"
+  integrity sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==
+  dependencies:
+    "@stablelib/binary" "^1.0.1"
+    "@stablelib/hash" "^1.0.1"
+    "@stablelib/wipe" "^1.0.1"
+
 "@stablelib/wipe@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stablelib/wipe/-/wipe-1.0.1.tgz#d21401f1d59ade56a62e139462a97f104ed19a36"
   integrity sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==
+
+"@stablelib/x25519@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@stablelib/x25519/-/x25519-1.0.3.tgz#13c8174f774ea9f3e5e42213cbf9fc68a3c7b7fd"
+  integrity sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==
+  dependencies:
+    "@stablelib/keyagreement" "^1.0.1"
+    "@stablelib/random" "^1.0.2"
+    "@stablelib/wipe" "^1.0.1"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
@@ -1725,6 +2029,257 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@walletconnect/core@2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.9.2.tgz#c46734ca63771b28fd77606fd521930b7ecfc5e1"
+  integrity sha512-VARMPAx8sIgodeyngDHbealP3B621PQqjqKsByFUTOep8ZI1/R/20zU+cmq6j9RCrL+kLKZcrZqeVzs8Z7OlqQ==
+  dependencies:
+    "@walletconnect/heartbeat" "1.2.1"
+    "@walletconnect/jsonrpc-provider" "1.0.13"
+    "@walletconnect/jsonrpc-types" "1.0.3"
+    "@walletconnect/jsonrpc-utils" "1.0.8"
+    "@walletconnect/jsonrpc-ws-connection" "1.0.13"
+    "@walletconnect/keyvaluestorage" "^1.0.2"
+    "@walletconnect/logger" "^2.0.1"
+    "@walletconnect/relay-api" "^1.0.9"
+    "@walletconnect/relay-auth" "^1.0.4"
+    "@walletconnect/safe-json" "^1.0.2"
+    "@walletconnect/time" "^1.0.2"
+    "@walletconnect/types" "2.9.2"
+    "@walletconnect/utils" "2.9.2"
+    events "^3.3.0"
+    lodash.isequal "4.5.0"
+    uint8arrays "^3.1.0"
+
+"@walletconnect/environment@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/environment/-/environment-1.0.1.tgz#1d7f82f0009ab821a2ba5ad5e5a7b8ae3b214cd7"
+  integrity sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==
+  dependencies:
+    tslib "1.14.1"
+
+"@walletconnect/ethereum-provider@2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.9.2.tgz#fb3a6fca279bb4e98e75baa2fb9730545d41bb99"
+  integrity sha512-eO1dkhZffV1g7vpG19XUJTw09M/bwGUwwhy1mJ3AOPbOSbMPvwiCuRz2Kbtm1g9B0Jv15Dl+TvJ9vTgYF8zoZg==
+  dependencies:
+    "@walletconnect/jsonrpc-http-connection" "^1.0.7"
+    "@walletconnect/jsonrpc-provider" "^1.0.13"
+    "@walletconnect/jsonrpc-types" "^1.0.3"
+    "@walletconnect/jsonrpc-utils" "^1.0.8"
+    "@walletconnect/sign-client" "2.9.2"
+    "@walletconnect/types" "2.9.2"
+    "@walletconnect/universal-provider" "2.9.2"
+    "@walletconnect/utils" "2.9.2"
+    events "^3.3.0"
+
+"@walletconnect/events@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/events/-/events-1.0.1.tgz#2b5f9c7202019e229d7ccae1369a9e86bda7816c"
+  integrity sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==
+  dependencies:
+    keyvaluestorage-interface "^1.0.0"
+    tslib "1.14.1"
+
+"@walletconnect/heartbeat@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz#afaa3a53232ae182d7c9cff41c1084472d8f32e9"
+  integrity sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==
+  dependencies:
+    "@walletconnect/events" "^1.0.1"
+    "@walletconnect/time" "^1.0.2"
+    tslib "1.14.1"
+
+"@walletconnect/jsonrpc-http-connection@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.8.tgz#2f4c3948f074960a3edd07909560f3be13e2c7ae"
+  integrity sha512-+B7cRuaxijLeFDJUq5hAzNyef3e3tBDIxyaCNmFtjwnod5AGis3RToNqzFU33vpVcxFhofkpE7Cx+5MYejbMGw==
+  dependencies:
+    "@walletconnect/jsonrpc-utils" "^1.0.6"
+    "@walletconnect/safe-json" "^1.0.1"
+    cross-fetch "^3.1.4"
+    events "^3.3.0"
+
+"@walletconnect/jsonrpc-provider@1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz#9a74da648d015e1fffc745f0c7d629457f53648b"
+  integrity sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==
+  dependencies:
+    "@walletconnect/jsonrpc-utils" "^1.0.8"
+    "@walletconnect/safe-json" "^1.0.2"
+    tslib "1.14.1"
+
+"@walletconnect/jsonrpc-provider@^1.0.13":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz#696f3e3b6d728b361f2e8b853cfc6afbdf2e4e3e"
+  integrity sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==
+  dependencies:
+    "@walletconnect/jsonrpc-utils" "^1.0.8"
+    "@walletconnect/safe-json" "^1.0.2"
+    events "^3.3.0"
+
+"@walletconnect/jsonrpc-types@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz#65e3b77046f1a7fa8347ae02bc1b841abe6f290c"
+  integrity sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==
+  dependencies:
+    keyvaluestorage-interface "^1.0.0"
+    tslib "1.14.1"
+
+"@walletconnect/jsonrpc-types@^1.0.2", "@walletconnect/jsonrpc-types@^1.0.3":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz#ce1a667d79eadf2a2d9d002c152ceb68739c230c"
+  integrity sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==
+  dependencies:
+    events "^3.3.0"
+    keyvaluestorage-interface "^1.0.0"
+
+"@walletconnect/jsonrpc-utils@1.0.8", "@walletconnect/jsonrpc-utils@^1.0.6", "@walletconnect/jsonrpc-utils@^1.0.7", "@walletconnect/jsonrpc-utils@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz#82d0cc6a5d6ff0ecc277cb35f71402c91ad48d72"
+  integrity sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==
+  dependencies:
+    "@walletconnect/environment" "^1.0.1"
+    "@walletconnect/jsonrpc-types" "^1.0.3"
+    tslib "1.14.1"
+
+"@walletconnect/jsonrpc-ws-connection@1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz#23b0cdd899801bfbb44a6556936ec2b93ef2adf4"
+  integrity sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==
+  dependencies:
+    "@walletconnect/jsonrpc-utils" "^1.0.6"
+    "@walletconnect/safe-json" "^1.0.2"
+    events "^3.3.0"
+    tslib "1.14.1"
+    ws "^7.5.1"
+
+"@walletconnect/keyvaluestorage@^1.0.2":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz#dd2caddabfbaf80f6b8993a0704d8b83115a1842"
+  integrity sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==
+  dependencies:
+    "@walletconnect/safe-json" "^1.0.1"
+    idb-keyval "^6.2.1"
+    unstorage "^1.9.0"
+
+"@walletconnect/logger@^2.0.1":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/logger/-/logger-2.1.2.tgz#813c9af61b96323a99f16c10089bfeb525e2a272"
+  integrity sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==
+  dependencies:
+    "@walletconnect/safe-json" "^1.0.2"
+    pino "7.11.0"
+
+"@walletconnect/relay-api@^1.0.9":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@walletconnect/relay-api/-/relay-api-1.0.11.tgz#80ab7ef2e83c6c173be1a59756f95e515fb63224"
+  integrity sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==
+  dependencies:
+    "@walletconnect/jsonrpc-types" "^1.0.2"
+
+"@walletconnect/relay-auth@^1.0.4":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@walletconnect/relay-auth/-/relay-auth-1.1.0.tgz#c3c5f54abd44a5138ea7d4fe77970597ba66c077"
+  integrity sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==
+  dependencies:
+    "@noble/curves" "1.8.0"
+    "@noble/hashes" "1.7.0"
+    "@walletconnect/safe-json" "^1.0.1"
+    "@walletconnect/time" "^1.0.2"
+    uint8arrays "^3.0.0"
+
+"@walletconnect/safe-json@^1.0.1", "@walletconnect/safe-json@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/safe-json/-/safe-json-1.0.2.tgz#7237e5ca48046e4476154e503c6d3c914126fa77"
+  integrity sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==
+  dependencies:
+    tslib "1.14.1"
+
+"@walletconnect/sign-client@2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.9.2.tgz#ff4c81c082c2078878367d07f24bcb20b1f7ab9e"
+  integrity sha512-anRwnXKlR08lYllFMEarS01hp1gr6Q9XUgvacr749hoaC/AwGVlxYFdM8+MyYr3ozlA+2i599kjbK/mAebqdXg==
+  dependencies:
+    "@walletconnect/core" "2.9.2"
+    "@walletconnect/events" "^1.0.1"
+    "@walletconnect/heartbeat" "1.2.1"
+    "@walletconnect/jsonrpc-utils" "1.0.8"
+    "@walletconnect/logger" "^2.0.1"
+    "@walletconnect/time" "^1.0.2"
+    "@walletconnect/types" "2.9.2"
+    "@walletconnect/utils" "2.9.2"
+    events "^3.3.0"
+
+"@walletconnect/time@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/time/-/time-1.0.2.tgz#6c5888b835750ecb4299d28eecc5e72c6d336523"
+  integrity sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==
+  dependencies:
+    tslib "1.14.1"
+
+"@walletconnect/types@2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.9.2.tgz#d5fd5a61dc0f41cbdca59d1885b85207ac7bf8c5"
+  integrity sha512-7Rdn30amnJEEal4hk83cdwHUuxI1SWQ+K7fFFHBMqkuHLGi3tpMY6kpyfDxnUScYEZXqgRps4Jo5qQgnRqVM7A==
+  dependencies:
+    "@walletconnect/events" "^1.0.1"
+    "@walletconnect/heartbeat" "1.2.1"
+    "@walletconnect/jsonrpc-types" "1.0.3"
+    "@walletconnect/keyvaluestorage" "^1.0.2"
+    "@walletconnect/logger" "^2.0.1"
+    events "^3.3.0"
+
+"@walletconnect/universal-provider@2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/universal-provider/-/universal-provider-2.9.2.tgz#40e54e98bc48b1f2f5f77eb5b7f05462093a8506"
+  integrity sha512-JmaolkO8D31UdRaQCHwlr8uIFUI5BYhBzqYFt54Mc6gbIa1tijGOmdyr6YhhFO70LPmS6gHIjljwOuEllmlrxw==
+  dependencies:
+    "@walletconnect/jsonrpc-http-connection" "^1.0.7"
+    "@walletconnect/jsonrpc-provider" "1.0.13"
+    "@walletconnect/jsonrpc-types" "^1.0.2"
+    "@walletconnect/jsonrpc-utils" "^1.0.7"
+    "@walletconnect/logger" "^2.0.1"
+    "@walletconnect/sign-client" "2.9.2"
+    "@walletconnect/types" "2.9.2"
+    "@walletconnect/utils" "2.9.2"
+    events "^3.3.0"
+
+"@walletconnect/utils@2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.9.2.tgz#035bdb859ee81a4bcc6420f56114cc5ec3e30afb"
+  integrity sha512-D44hwXET/8JhhIjqljY6qxSu7xXnlPrf63UN/Qfl98vDjWlYVcDl2+JIQRxD9GPastw0S8XZXdRq59XDXLuZBg==
+  dependencies:
+    "@stablelib/chacha20poly1305" "1.0.1"
+    "@stablelib/hkdf" "1.0.1"
+    "@stablelib/random" "^1.0.2"
+    "@stablelib/sha256" "1.0.1"
+    "@stablelib/x25519" "^1.0.3"
+    "@walletconnect/relay-api" "^1.0.9"
+    "@walletconnect/safe-json" "^1.0.2"
+    "@walletconnect/time" "^1.0.2"
+    "@walletconnect/types" "2.9.2"
+    "@walletconnect/window-getters" "^1.0.1"
+    "@walletconnect/window-metadata" "^1.0.1"
+    detect-browser "5.3.0"
+    query-string "7.1.3"
+    uint8arrays "^3.1.0"
+
+"@walletconnect/window-getters@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/window-getters/-/window-getters-1.0.1.tgz#f36d1c72558a7f6b87ecc4451fc8bd44f63cbbdc"
+  integrity sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==
+  dependencies:
+    tslib "1.14.1"
+
+"@walletconnect/window-metadata@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz#2124f75447b7e989e4e4e1581d55d25bc75f7be5"
+  integrity sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==
+  dependencies:
+    "@walletconnect/window-getters" "^1.0.1"
+    tslib "1.14.1"
+
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -1791,7 +2346,7 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-anymatch@^3.0.3, anymatch@~3.1.2:
+anymatch@^3.0.3, anymatch@^3.1.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -1850,6 +2405,11 @@ asn1js@^3.0.5:
     pvutils "^1.1.3"
     tslib "^2.4.0"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 async@^3.2.3:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
@@ -1859,6 +2419,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
 available-typed-arrays@^1.0.7:
   version "1.0.7"
@@ -1935,11 +2500,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-x@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
-  integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
-
 base64-js@^1.3.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -1950,7 +2510,7 @@ base64url@^3.0.1:
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
   integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
 
-bech32@1.1.4, bech32@^1.1.4:
+bech32@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
@@ -1970,29 +2530,17 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
-bip174@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/bip174/-/bip174-2.1.1.tgz#ef3e968cf76de234a546962bcf572cc150982f9f"
-  integrity sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==
-
-bitcoinjs-lib@^6.1.0:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/bitcoinjs-lib/-/bitcoinjs-lib-6.1.6.tgz#f57c17c82511f860f11946d784c18da39f8618a8"
-  integrity sha512-Fk8+Vc+e2rMoDU5gXkW9tD+313rhkm5h6N9HfZxXvYU9LedttVvmXKTgd9k5rsQJjkSfsv6XRM8uhJv94SrvcA==
-  dependencies:
-    "@noble/hashes" "^1.2.0"
-    bech32 "^2.0.0"
-    bip174 "^2.1.1"
-    bs58check "^3.0.1"
-    typeforce "^1.11.3"
-    varuint-bitcoin "^1.1.2"
-
 bn.js@^4.0.0, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
-bn.js@^5.2.0, bn.js@^5.2.1:
+bn.js@^4.11.8:
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.1.tgz#215741fe3c9dba2d7e12c001d0cfdbae43975ba7"
+  integrity sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==
+
+bn.js@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
@@ -2058,21 +2606,6 @@ bs-logger@^0.2.6:
   integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
   dependencies:
     fast-json-stable-stringify "2.x"
-
-bs58@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
-  integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==
-  dependencies:
-    base-x "^4.0.0"
-
-bs58check@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-3.0.1.tgz#2094d13720a28593de1cba1d8c4e48602fdd841c"
-  integrity sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==
-  dependencies:
-    "@noble/hashes" "^1.2.0"
-    bs58 "^5.0.0"
 
 bser@2.1.1:
   version "2.1.1"
@@ -2148,6 +2681,11 @@ canonicalize@^2.0.0:
   resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-2.0.0.tgz#32be2cef4446d67fd5348027a384cae28f17226a"
   integrity sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w==
 
+cbor-web@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/cbor-web/-/cbor-web-9.0.2.tgz#1915f1ef1a72ea905db07480f71cf12ff601c661"
+  integrity sha512-N6gU2GsJS8RR5gy1d9wQcSPgn9FGJFY7KNvdDRlwHfz6kCxrQr2TDnrjXHmr6TFSl6Fd0FC4zRnityEldjRGvQ==
+
 cbor@*:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/cbor/-/cbor-9.0.2.tgz#536b4f2d544411e70ec2b19a2453f10f83cd9fdb"
@@ -2183,7 +2721,7 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-chokidar@^3.5.2:
+chokidar@^3.5.2, chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
@@ -2278,6 +2816,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie-es@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cookie-es/-/cookie-es-1.2.2.tgz#18ceef9eb513cac1cb6c14bcbf8bdb2679b34821"
+  integrity sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -2292,11 +2835,6 @@ cookiejar@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
   integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
-
-core-util-is@~1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
-  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cors@^2.8.5:
   version "2.8.5"
@@ -2324,12 +2862,19 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
-  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+cross-fetch@3.1.8:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
   dependencies:
-    node-fetch "2.6.1"
+    node-fetch "^2.6.12"
+
+cross-fetch@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.2.0.tgz#34e9192f53bc757d6614304d9e5e6fb4edb782e3"
+  integrity sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==
+  dependencies:
+    node-fetch "^2.7.0"
 
 cross-spawn@^7.0.3:
   version "7.0.6"
@@ -2339,6 +2884,13 @@ cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crossws@^0.3.3:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/crossws/-/crossws-0.3.4.tgz#06164c6495ea99152ea7557c99310b52d9be9b29"
+  integrity sha512-uj0O1ETYX1Bh6uSgktfPvwDiPYGQ3aI4qVsaC/LWpkIzGj1nUYm5FK3K+t11oOlpN01lGbprFCH4wBlKdJjVgw==
+  dependencies:
+    uncrypto "^0.1.3"
 
 date-and-time@^2.4.1:
   version "2.4.3"
@@ -2366,6 +2918,11 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
+decode-uri-component@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
+
 dedent@^1.0.0:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.5.3.tgz#99aee19eb9bae55a67327717b6e848d0bf777e5a"
@@ -2385,20 +2942,35 @@ define-data-property@^1.1.4:
     es-errors "^1.3.0"
     gopd "^1.0.1"
 
+defu@^6.1.4:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.4.tgz#4e0c9cf9ff68fe5f3d7f2765cc1a012dfdcb0479"
+  integrity sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-depd@2.0.0:
+depd@2.0.0, depd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
+destr@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/destr/-/destr-2.0.3.tgz#7f9e97cb3d16dbdca7be52aca1644ce402cfe449"
+  integrity sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==
 
 destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
+
+detect-browser@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-5.3.0.tgz#9705ef2bddf46072d0f7265a1fe300e36fe7ceca"
+  integrity sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -2436,6 +3008,16 @@ dunder-proto@^1.0.1:
     call-bind-apply-helpers "^1.0.1"
     es-errors "^1.3.0"
     gopd "^1.2.0"
+
+duplexify@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.3.tgz#a07e1c0d0a2c001158563d32592ba58bddb0236f"
+  integrity sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==
+  dependencies:
+    end-of-stream "^1.4.1"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+    stream-shift "^1.0.2"
 
 ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
   version "1.0.11"
@@ -2507,6 +3089,13 @@ encodeurl@~2.0.0:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
+end-of-stream@^1.4.1:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
+
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -2563,7 +3152,17 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-ethereum-cryptography@^2.1.3:
+ethereum-cryptography@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz#5ccfa183e85fdaf9f9b299a79430c044268c9b3a"
+  integrity sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==
+  dependencies:
+    "@noble/hashes" "1.2.0"
+    "@noble/secp256k1" "1.7.1"
+    "@scure/bip32" "1.1.5"
+    "@scure/bip39" "1.1.1"
+
+ethereum-cryptography@^2.0.0, ethereum-cryptography@^2.1.3:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz#58f2810f8e020aecb97de8c8c76147600b0b8ccf"
   integrity sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==
@@ -2608,6 +3207,19 @@ ethers@^5.7.1, ethers@^5.7.2:
     "@ethersproject/wallet" "5.7.0"
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
+
+ethjs-util@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
+  integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
+  dependencies:
+    is-hex-prefixed "1.0.0"
+    strip-hex-prefix "1.0.0"
+
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 execa@^5.0.0:
   version "5.1.1"
@@ -2697,6 +3309,11 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
+fast-redact@^3.0.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.5.0.tgz#e9ea02f7e57d0cd8438180083e93077e496285e4"
+  integrity sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==
+
 fast-safe-stringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
@@ -2732,6 +3349,11 @@ fill-range@^7.1.1:
   integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
 
 finalhandler@1.2.0:
   version "1.2.0"
@@ -2954,6 +3576,22 @@ gtoken@^6.1.0:
     google-p12-pem "^4.0.0"
     jws "^4.0.0"
 
+h3@^1.13.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/h3/-/h3-1.15.0.tgz#1a149cbe8c0418691cae331d5744c0c65fbf42b3"
+  integrity sha512-OsjX4JW8J4XGgCgEcad20pepFQWnuKH+OwkCJjogF3C+9AZ1iYdtB4hX6vAb5DskBiu5ljEXqApINjR8CqoCMQ==
+  dependencies:
+    cookie-es "^1.2.2"
+    crossws "^0.3.3"
+    defu "^6.1.4"
+    destr "^2.0.3"
+    iron-webcrypto "^1.2.1"
+    node-mock-http "^1.0.0"
+    ohash "^1.1.4"
+    radix3 "^1.1.2"
+    ufo "^1.5.4"
+    uncrypto "^0.1.3"
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -3058,15 +3696,15 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+idb-keyval@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-6.2.1.tgz#94516d625346d16f56f3b33855da11bfded2db33"
+  integrity sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==
+
 ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
-
-immediate@~3.0.5:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
-  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
 
 import-local@^3.0.2:
   version "3.2.0"
@@ -3089,7 +3727,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3103,6 +3741,11 @@ ipaddr.js@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.2.0.tgz#d33fa7bac284f4de7af949638c9d68157c6b92e8"
   integrity sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==
+
+iron-webcrypto@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz#aa60ff2aa10550630f4c0b11fd2442becdb35a6f"
+  integrity sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==
 
 is-arguments@^1.0.4:
   version "1.1.1"
@@ -3165,6 +3808,11 @@ is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-hex-prefixed@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
+  integrity sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -3181,11 +3829,6 @@ is-typed-array@^1.1.3:
   integrity sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==
   dependencies:
     which-typed-array "^1.1.14"
-
-isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -3673,16 +4316,6 @@ jsrsasign@^10.4.0:
   resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-10.9.0.tgz#cc3f316e7e4c112a976193f9d2c93deb5a0745ee"
   integrity sha512-QWLUikj1SBJGuyGK8tjKSx3K7Y69KYJnrs/pQ1KZ6wvZIkHkWjZ1PJDpuvc1/28c1uP0KW9qn1eI1LzHQqDOwQ==
 
-jszip@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
-  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
-  dependencies:
-    lie "~3.3.0"
-    pako "~1.0.2"
-    readable-stream "~2.3.6"
-    setimmediate "^1.0.5"
-
 jwa@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.0.tgz#a7e9c3f29dae94027ebcaf49975c9345593410fc"
@@ -3709,6 +4342,11 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
+keyvaluestorage-interface@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz#13ebdf71f5284ad54be94bd1ad9ed79adad515ff"
+  integrity sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -3718,25 +4356,6 @@ leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
-
-libsodium-wrappers@^0.7.6:
-  version "0.7.14"
-  resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.14.tgz#b21d9e8d58de686c6318a772805ee1c5d02035a5"
-  integrity sha512-300TtsePizhJZ7HjLmWr6hLHAgJUxIGhapSw+EwfCtDuWaEmEdGXSQv6j6qFw0bs9l4vS2NH9BtOHfXAq6h5kQ==
-  dependencies:
-    libsodium "^0.7.14"
-
-libsodium@^0.7.14:
-  version "0.7.14"
-  resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.7.14.tgz#d9daace70dbc36051b947d37999bb6337c364c88"
-  integrity sha512-/pOd7eO6oZrfORquRTC4284OUJFcMi8F3Vnc9xtRBT0teLfOUxWIItaBFF3odYjZ7nlJNwnLdUVEUFHxVyX/Sw==
-
-lie@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
-  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
-  dependencies:
-    immediate "~3.0.5"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -3750,10 +4369,20 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.isequal@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
+lru-cache@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -3812,6 +4441,11 @@ methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
+
+micro-ftch@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/micro-ftch/-/micro-ftch-0.3.1.tgz#6cb83388de4c1f279a034fb0cf96dfc050853c5f"
+  integrity sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==
 
 micromatch@^4.0.4:
   version "4.0.8"
@@ -3887,11 +4521,6 @@ multiformats@^11.0.2:
   resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-11.0.2.tgz#b14735efc42cd8581e73895e66bebb9752151b60"
   integrity sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==
 
-multiformats@^12.0.1:
-  version "12.1.3"
-  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-12.1.3.tgz#cbf7a9861e11e74f8228b21376088cb43ba8754e"
-  integrity sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==
-
 multiformats@^9.4.2, multiformats@^9.7.1:
   version "9.9.0"
   resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.9.0.tgz#c68354e7d21037a8f1f8833c8ccd68618e8f1d37"
@@ -3907,12 +4536,12 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+node-fetch-native@^1.6.4:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.6.tgz#ae1d0e537af35c2c0b0de81cbff37eedd410aa37"
+  integrity sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==
 
-node-fetch@^2.6.0, node-fetch@^2.6.9:
+node-fetch@^2.6.0, node-fetch@^2.6.12, node-fetch@^2.6.9, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -3928,6 +4557,11 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
+
+node-mock-http@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-mock-http/-/node-mock-http-1.0.0.tgz#4b32cd509c7f46d844e68ea93fb8be405a18a42a"
+  integrity sha512-0uGYQ1WQL1M5kKvGRXWQ3uZCHtLTO8hln3oBjIusM75WoesZ909uQJs/Hb946i2SS+Gsrhkaa6iAO17jRIv6DQ==
 
 node-releases@^2.0.19:
   version "2.0.19"
@@ -3987,6 +4621,25 @@ object-inspect@^1.13.3:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
 
+ofetch@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/ofetch/-/ofetch-1.4.1.tgz#b6bf6b0d75ba616cef6519dd8b6385a8bae480ec"
+  integrity sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==
+  dependencies:
+    destr "^2.0.3"
+    node-fetch-native "^1.6.4"
+    ufo "^1.5.4"
+
+ohash@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/ohash/-/ohash-1.1.4.tgz#ae8d83014ab81157d2c285abf7792e2995fadd72"
+  integrity sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==
+
+on-exit-leak-free@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz#b39c9e3bf7690d890f4861558b0d7b90a442d209"
+  integrity sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==
+
 on-finished@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
@@ -4034,10 +4687,10 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-pako@1.0.11, pako@~1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+pako@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 parse-json@^5.2.0:
   version "5.2.0"
@@ -4089,6 +4742,36 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+pino-abstract-transport@v0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz#4b54348d8f73713bfd14e3dc44228739aa13d9c0"
+  integrity sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==
+  dependencies:
+    duplexify "^4.1.2"
+    split2 "^4.0.0"
+
+pino-std-serializers@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz#1791ccd2539c091ae49ce9993205e2cd5dbba1e2"
+  integrity sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==
+
+pino@7.11.0:
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-7.11.0.tgz#0f0ea5c4683dc91388081d44bff10c83125066f6"
+  integrity sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    fast-redact "^3.0.0"
+    on-exit-leak-free "^0.2.0"
+    pino-abstract-transport v0.5.0
+    pino-std-serializers "^4.0.0"
+    process-warning "^1.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.1.0"
+    safe-stable-stringify "^2.1.0"
+    sonic-boom "^2.2.1"
+    thread-stream "^0.15.1"
+
 pirates@^4.0.4:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
@@ -4115,10 +4798,10 @@ pretty-format@^29.0.0, pretty-format@^29.7.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-process-nextick-args@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+process-warning@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-1.0.0.tgz#980a0b25dc38cd6034181be4b7726d89066b4616"
+  integrity sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==
 
 process@0.11.10:
   version "0.11.10"
@@ -4146,7 +4829,7 @@ pstree.remy@^1.1.8:
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
-punycode@2.3.1, punycode@^2.1.0:
+punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -4189,6 +4872,26 @@ qs@^6.11.0:
   dependencies:
     side-channel "^1.1.0"
 
+query-string@7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
+  integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
+  dependencies:
+    decode-uri-component "^0.2.2"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
+quick-format-unescaped@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
+  integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
+
+radix3@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/radix3/-/radix3-1.1.2.tgz#fd27d2af3896c6bf4bcdfab6427c69c2afc69ec0"
+  integrity sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==
+
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -4214,18 +4917,14 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-readable-stream@~2.3.6:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
-  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+readable-stream@^3.1.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
   dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -4234,10 +4933,10 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-readonly-date@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/readonly-date/-/readonly-date-1.0.0.tgz#5af785464d8c7d7c40b9d738cbde8c646f97dcd9"
-  integrity sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ==
+real-require@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.1.0.tgz#736ac214caa20632847b7ca8c1056a0767df9381"
+  integrity sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==
 
 redis@^4.4.0:
   version "4.6.15"
@@ -4287,15 +4986,15 @@ resolve@^1.20.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.1:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+safe-stable-stringify@^2.1.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
+  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
 
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.1.0:
   version "2.1.2"
@@ -4386,11 +5085,6 @@ set-function-length@^1.2.1:
     get-intrinsic "^1.2.4"
     gopd "^1.0.1"
     has-property-descriptors "^1.0.2"
-
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 setprototypeof@1.2.0:
   version "1.2.0"
@@ -4485,7 +5179,7 @@ siwe-recap@0.0.2-alpha.0:
     multiformats "^11.0.2"
     siwe "^2.1.4"
 
-siwe@^2.0.5, siwe@^2.1.4, siwe@^2.3.2:
+siwe@^2.1.4, siwe@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/siwe/-/siwe-2.3.2.tgz#0794ae25f734f3068de0ab093ddd2f7867bc2d67"
   integrity sha512-aSf+6+Latyttbj5nMu6GF3doMfv2UYj83hhwZgUF20ky6fTS83uVhkQABdIVnEuS8y1bBdk7p6ltb9SmlhTTlA==
@@ -4500,6 +5194,13 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+sonic-boom@^2.2.1:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-2.8.0.tgz#c1def62a77425090e6ad7516aad8eb402e047611"
+  integrity sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==
+  dependencies:
+    atomic-sleep "^1.0.0"
+
 source-map-support@0.5.13:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
@@ -4512,6 +5213,21 @@ source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
+split2@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
+
+sprintf-js@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
+  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -4530,6 +5246,16 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
+stream-shift@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.3.tgz#85b8fab4d71010fc3ba8772e8046cc49b8a3864b"
+  integrity sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
+
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -4547,12 +5273,12 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
-    safe-buffer "~5.1.0"
+    safe-buffer "~5.2.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -4570,6 +5296,13 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-hex-prefix@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz#0c5f155fef1151373377de9dbb588da05500e36f"
+  integrity sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==
+  dependencies:
+    is-hex-prefixed "1.0.0"
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -4633,6 +5366,13 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+thread-stream@^0.15.1:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-0.15.2.tgz#fb95ad87d2f1e28f07116eb23d85aba3bc0425f4"
+  integrity sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==
+  dependencies:
+    real-require "^0.1.0"
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -4700,15 +5440,15 @@ tslib@1.14.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
-  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
-
-tslib@^2.3.0, tslib@^2.4.0, tslib@^2.6.1, tslib@^2.6.2:
+tslib@^2.4.0, tslib@^2.6.1, tslib@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
+
+tslib@^2.7.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tweetnacl-util@^0.15.1:
   version "0.15.1"
@@ -4738,29 +5478,27 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typeforce@^1.11.3:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
-  integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
-
 typescript@^4.4.2:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-uint8arrays@^3.0.0:
+ufo@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.5.4.tgz#16d6949674ca0c9e0fbbae1fa20a71d7b1ded754"
+  integrity sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==
+
+uint8arrays@^3.0.0, uint8arrays@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-3.1.1.tgz#2d8762acce159ccd9936057572dade9459f65ae0"
   integrity sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==
   dependencies:
     multiformats "^9.4.2"
 
-uint8arrays@^4.0.3:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-4.0.10.tgz#3ec5cde3348903c140e87532fc53f46b8f2e921f"
-  integrity sha512-AnJNUGGDJAgFw/eWu/Xb9zrVKEGlwJJCaeInlf3BkecE/zcTobk5YXYIPNQJO1q5Hh1QZrQQHf0JvcHqz2hqoA==
-  dependencies:
-    multiformats "^12.0.1"
+uncrypto@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/uncrypto/-/uncrypto-0.1.3.tgz#e1288d609226f2d02d8d69ee861fa20d8348ef2b"
+  integrity sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==
 
 undefsafe@^2.0.5:
   version "2.0.5"
@@ -4777,6 +5515,20 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
+unstorage@^1.9.0:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/unstorage/-/unstorage-1.14.4.tgz#620dd68997a3245fca1e04c0171335817525bc3d"
+  integrity sha512-1SYeamwuYeQJtJ/USE1x4l17LkmQBzg7deBJ+U9qOBoHo15d1cDxG4jM31zKRgF7pG0kirZy4wVMX6WL6Zoscg==
+  dependencies:
+    anymatch "^3.1.3"
+    chokidar "^3.6.0"
+    destr "^2.0.3"
+    h3 "^1.13.0"
+    lru-cache "^10.4.3"
+    node-fetch-native "^1.6.4"
+    ofetch "^1.4.1"
+    ufo "^1.5.4"
+
 update-browserslist-db@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz#97e9c96ab0ae7bcac08e9ae5151d26e6bc6b5580"
@@ -4792,7 +5544,7 @@ uri-js@^4.4.1:
   dependencies:
     punycode "^2.1.0"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
@@ -4831,13 +5583,6 @@ valid-url@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
   integrity sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==
-
-varuint-bitcoin@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz#e76c138249d06138b480d4c5b40ef53693e24e92"
-  integrity sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==
-  dependencies:
-    safe-buffer "^5.1.1"
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"
@@ -4908,6 +5653,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@^7.5.1:
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
Added a new `pkp-sign` route which uses an `AuthMethod` to sign with a specified PKP public key. Tested on all networks.

Updated Lit imports to `7.0.6`

Removed deprecated network support (WIP)